### PR TITLE
Fix ChatAdmin goal parameter bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,15 @@ json_messages = [{'sender_id': 'Bruno', 'message': 'It’s a test, don’t worry
 chat.add_messages(json_messages)
 
 # Initialize and configure ChatAdmin
-chat_admin = ChatAdmin("admin", "Admin", "admin_role", pipeline_admin, chat, 10)
+chat_admin = ChatAdmin(
+    "admin",
+    "Admin",
+    "admin_role",
+    pipeline_admin,
+    chat,
+    "manage_chat",
+    10,
+)
 
 #running the chat
 chat_admin.run()

--- a/docs/eng/chat_admin.md
+++ b/docs/eng/chat_admin.md
@@ -17,9 +17,10 @@ The `ChatAdmin` class, an extension of the `Agent` class in MiniAutoGen, is desi
   - `agent_id` (`str`): The unique identifier of the agent.
   - `name` (`str`): The name of the agent.
   - `role` (`str`): The role of the agent in the chat.
-  - `pipeline` (`Pipeline`): The pipeline used for processing chat messages.
-  - `group_chat` (`GroupChat`): The group chat object to be managed.
-  - `max_rounds` (`int`): The maximum number of chat rounds to be executed.
+    - `pipeline` (`Pipeline`): The pipeline used for processing chat messages.
+    - `group_chat` (`GroupChat`): The group chat object to be managed.
+    - `goal` (`str`): The goal that guides the conversation.
+    - `max_rounds` (`int`): The maximum number of chat rounds to be executed.
 
 #### Public Methods:
 ##### `start(self)`
@@ -45,9 +46,10 @@ The `ChatAdmin` class, an extension of the `Agent` class in MiniAutoGen, is desi
 - **Purpose**: Creates a `ChatAdmin` object from JSON data.
 - **Parameters**:
   - `json_data` (`dict`): The JSON data containing agent information.
-  - `pipeline` (`Pipeline`): The pipeline for processing chat messages.
-  - `group_chat` (`GroupChat`): The group chat object.
-  - `max_rounds` (`int`): The maximum number of chat rounds.
+    - `pipeline` (`Pipeline`): The pipeline for processing chat messages.
+    - `group_chat` (`GroupChat`): The group chat object.
+    - `goal` (`str`): The goal that guides the conversation.
+    - `max_rounds` (`int`): The maximum number of chat rounds.
 - **Returns**: A `ChatAdmin` object.
 - **Raises**: `ValueError` if the JSON data lacks required keys.
 
@@ -55,14 +57,15 @@ The `ChatAdmin` class, an extension of the `Agent` class in MiniAutoGen, is desi
 
 ### Creating a ChatAdmin
 ```python
-chat_admin = ChatAdmin(
-    agent_id="admin1",
-    name="ChatController",
-    role="Administrator",
-    pipeline=my_pipeline,
-    group_chat=my_group_chat,
-    max_rounds=10
-)
+ chat_admin = ChatAdmin(
+     agent_id="admin1",
+     name="ChatController",
+     role="Administrator",
+     pipeline=my_pipeline,
+     group_chat=my_group_chat,
+     goal="manage_chat",
+     max_rounds=10
+ )
 ```
 
 ### Running Chat Rounds
@@ -80,6 +83,10 @@ Assuming `json_data` contains required keys and valid objects for `pipeline` and
 ```python
 json_data = {"agent_id": "admin2", "name": "SessionManager", "role": "Coordinator"}
 chat_admin_from_json = ChatAdmin.from_json(
-    json_data, my_pipeline, my_group_chat, 5
+    json_data,
+    my_pipeline,
+    my_group_chat,
+    "manage_chat",
+    5,
 )
 ```

--- a/miniautogen/chat/chatadmin.py
+++ b/miniautogen/chat/chatadmin.py
@@ -6,7 +6,7 @@ import logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 class ChatAdmin(Agent):
-    def __init__(self, agent_id, name, role, pipeline, group_chat, max_rounds):
+    def __init__(self, agent_id, name, role, pipeline, group_chat, goal, max_rounds):
         """
         Initializes a ChatAdmin object.
 
@@ -16,11 +16,13 @@ class ChatAdmin(Agent):
             role (str): The role of the agent.
             pipeline (Pipeline): The pipeline to be used for processing chat messages.
             group_chat (GroupChat): The group chat object.
+            goal (str): The goal that guides the conversation.
             max_rounds (int): The maximum number of chat rounds to execute.
         """
         super().__init__(agent_id, name, role)
         self.pipeline = pipeline
         self.group_chat = group_chat
+        self.goal = goal
         self.round = 0
         self.max_rounds = max_rounds
         self.running = False


### PR DESCRIPTION
## Summary
- add `goal` parameter to `ChatAdmin.__init__` and store it
- document the new parameter in docs and README examples

## Testing
- `python -m compileall -q miniautogen`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6850d52a129c8323a9b42cffe47f3eda