### PR TITLE
test(core): add deepdiff immutability guards and QA infrastructure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,18 +46,18 @@ dev = [
     "ruff>=0.15.0",
     "mypy>=1.9.0",
     "hypothesis>=6.130.0",
-    "deepdiff>=7.0.0",
+    "deepdiff>=7.0.0,<9.0.0",
 ]
 
 [tool.ruff]
 line-length = 100
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 warn_unused_configs = true
 check_untyped_defs = true
 ignore_missing_imports = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ def assert_no_mutation(
     before_snapshot: dict[str, Any],
     after_snapshot: dict[str, Any],
     label: str = "",
+    ignore_order: bool = False,
 ) -> None:
     """Assert that two snapshots are structurally identical.
 
@@ -21,6 +22,8 @@ def assert_no_mutation(
         before_snapshot: State captured before the operation.
         after_snapshot: State captured after the operation.
         label: Optional label for the error message.
+        ignore_order: Whether to ignore list ordering during comparison.
+            Defaults to False (order matters) for strict mutation detection.
     """
-    diff = DeepDiff(before_snapshot, after_snapshot, ignore_order=True)
+    diff = DeepDiff(before_snapshot, after_snapshot, ignore_order=ignore_order)
     assert diff == {}, f"Immutability violation{' in ' + label if label else ''}: {diff}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Root conftest.py -- shared test fixtures and helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from deepdiff import DeepDiff
+
+
+def assert_no_mutation(
+    before_snapshot: dict[str, Any],
+    after_snapshot: dict[str, Any],
+    label: str = "",
+) -> None:
+    """Assert that two snapshots are structurally identical.
+
+    Uses DeepDiff for deep comparison. Raises AssertionError with
+    a detailed diff message if any mutation is detected.
+
+    Args:
+        before_snapshot: State captured before the operation.
+        after_snapshot: State captured after the operation.
+        label: Optional label for the error message.
+    """
+    diff = DeepDiff(before_snapshot, after_snapshot, ignore_order=True)
+    assert diff == {}, f"Immutability violation{' in ' + label if label else ''}: {diff}"

--- a/tests/core/contracts/test_immutability.py
+++ b/tests/core/contracts/test_immutability.py
@@ -1,0 +1,157 @@
+"""Immutability invariant tests using DeepDiff.
+
+These tests enforce Architectural Invariant 1 (Immutability) by verifying
+that framework models do not mutate their inputs or leak shared references.
+"""
+
+from __future__ import annotations
+
+import copy
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from deepdiff import DeepDiff
+
+from miniautogen.core.contracts.events import ExecutionEvent
+from miniautogen.core.contracts.run_context import RunContext
+
+# ---------------------------------------------------------------------------
+# Import the shared helper (available via tests/conftest.py)
+# ---------------------------------------------------------------------------
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from conftest import assert_no_mutation
+
+
+# ---------------------------------------------------------------------------
+# ExecutionEvent immutability tests
+# ---------------------------------------------------------------------------
+
+
+class TestExecutionEventImmutability:
+    """Verify ExecutionEvent does not mutate inputs."""
+
+    def test_payload_dict_not_mutated_by_construction(self) -> None:
+        """Creating an ExecutionEvent must not mutate the input payload dict."""
+        original_payload: dict[str, Any] = {"run_id": "run-123", "data": "value"}
+        snapshot = copy.deepcopy(original_payload)
+
+        # Construction triggers infer_run_id_from_payload validator
+        _event = ExecutionEvent(type="test", payload=original_payload)
+
+        assert_no_mutation(snapshot, original_payload, "ExecutionEvent payload input")
+
+    def test_event_serialization_round_trip(self) -> None:
+        """model_dump_json -> model_validate_json produces zero diff."""
+        event = ExecutionEvent(
+            type="component_finished",
+            run_id="run-1",
+            payload={"step": 3, "data": [1, 2, 3]},
+        )
+        json_str = event.model_dump_json()
+        restored = ExecutionEvent.model_validate_json(json_str)
+
+        diff = DeepDiff(
+            event.model_dump(mode="python"),
+            restored.model_dump(mode="python"),
+        )
+        assert diff == {}, f"Event round-trip fidelity violation: {diff}"
+
+    @pytest.mark.xfail(
+        reason="Known violation: infer_run_id_from_payload mutates self.run_id in model_validator(mode='after'). "
+               "Tracked for refactoring in WS2 (Immutable Core).",
+        strict=True,
+    )
+    def test_event_run_id_inference_does_not_mutate_self(self) -> None:
+        """The model_validator should not mutate self -- it should use model_copy or __init__.
+
+        This test documents the known violation: the validator sets self.run_id
+        directly, which is a mutation of the model after construction.
+        """
+        event = ExecutionEvent(type="test", payload={"run_id": "inferred-123"})
+        # The validator mutated self.run_id -- this is the violation.
+        # In an ideal world, run_id would be set during __init__, not via mutation.
+        # We mark this xfail to document the violation; WS2 will fix it.
+        assert event.run_id is None  # This WILL fail because run_id was mutated to "inferred-123"
+
+
+# ---------------------------------------------------------------------------
+# RunContext immutability tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunContextImmutability:
+    """Verify RunContext operations produce isolated copies."""
+
+    def _make_context(self, **overrides: Any) -> RunContext:
+        defaults: dict[str, Any] = {
+            "run_id": "run-1",
+            "started_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+            "correlation_id": "corr-1",
+            "execution_state": {"step": 1, "data": [1, 2, 3]},
+            "metadata": {"source": "test"},
+        }
+        defaults.update(overrides)
+        return RunContext(**defaults)  # type: ignore[arg-type]
+
+    def test_with_previous_result_does_not_mutate_original(self) -> None:
+        """Calling with_previous_result must not change the original context."""
+        ctx = self._make_context()
+        snapshot = ctx.model_dump(mode="python")
+
+        _child = ctx.with_previous_result({"output": "data"})
+
+        assert_no_mutation(
+            snapshot,
+            ctx.model_dump(mode="python"),
+            "RunContext after with_previous_result",
+        )
+
+    @pytest.mark.xfail(
+        reason="Pydantic model_copy performs shallow copy of execution_state. "
+               "Tracked for fix in WS2 (Immutable Core).",
+        strict=True,
+    )
+    def test_execution_state_isolated_on_copy(self) -> None:
+        """execution_state in the child must be a distinct object."""
+        ctx = self._make_context()
+        child = ctx.with_previous_result({"output": "data"})
+
+        # Identity check: must NOT be the same dict object
+        assert child.execution_state is not ctx.execution_state
+
+    def test_metadata_isolated_on_copy(self) -> None:
+        """metadata in the child must be a distinct object (it uses spread)."""
+        ctx = self._make_context()
+        child = ctx.with_previous_result({"output": "data"})
+
+        # Identity check: must NOT be the same dict object
+        assert child.metadata is not ctx.metadata
+
+    def test_metadata_changes_do_not_leak_back(self) -> None:
+        """Mutating child metadata must not affect parent metadata."""
+        ctx = self._make_context()
+        child = ctx.with_previous_result({"output": "data"})
+
+        # Mutate the child's metadata
+        child.metadata["injected"] = "should_not_leak"
+
+        assert "injected" not in ctx.metadata
+
+    @pytest.mark.xfail(
+        reason="Pydantic model_copy performs shallow copy of execution_state. "
+               "Tracked for fix in WS2 (Immutable Core).",
+        strict=True,
+    )
+    def test_execution_state_changes_do_not_leak_back(self) -> None:
+        """Mutating child execution_state must not affect parent."""
+        ctx = self._make_context()
+        child = ctx.with_previous_result({"output": "data"})
+
+        # Mutate the child's execution_state
+        child.execution_state["injected"] = "should_not_leak"
+
+        assert "injected" not in ctx.execution_state

--- a/tests/core/contracts/test_immutability.py
+++ b/tests/core/contracts/test_immutability.py
@@ -7,7 +7,13 @@ that framework models do not mutate their inputs or leak shared references.
 from __future__ import annotations
 
 import copy
+
+# ---------------------------------------------------------------------------
+# Import the shared helper (available via tests/conftest.py)
+# ---------------------------------------------------------------------------
+import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -16,15 +22,8 @@ from deepdiff import DeepDiff
 from miniautogen.core.contracts.events import ExecutionEvent
 from miniautogen.core.contracts.run_context import RunContext
 
-# ---------------------------------------------------------------------------
-# Import the shared helper (available via tests/conftest.py)
-# ---------------------------------------------------------------------------
-import sys
-from pathlib import Path
-
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from conftest import assert_no_mutation
-
 
 # ---------------------------------------------------------------------------
 # ExecutionEvent immutability tests
@@ -61,8 +60,10 @@ class TestExecutionEventImmutability:
         assert diff == {}, f"Event round-trip fidelity violation: {diff}"
 
     @pytest.mark.xfail(
-        reason="Known violation: infer_run_id_from_payload mutates self.run_id in model_validator(mode='after'). "
-               "Tracked for refactoring in WS2 (Immutable Core).",
+        reason=(
+            "Known violation: infer_run_id_from_payload mutates self.run_id in "
+            "model_validator(mode='after'). Tracked for refactoring in WS2 (Immutable Core)."
+        ),
         strict=True,
     )
     def test_event_run_id_inference_does_not_mutate_self(self) -> None:

--- a/tests/stores/test_store_round_trip.py
+++ b/tests/stores/test_store_round_trip.py
@@ -1,0 +1,82 @@
+"""Store round-trip fidelity tests using DeepDiff.
+
+Verifies that save -> load produces structurally identical data
+for both CheckpointStore and RunStore implementations.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from deepdiff import DeepDiff
+
+from miniautogen.stores.sqlalchemy_checkpoint_store import SQLAlchemyCheckpointStore
+from miniautogen.stores.sqlalchemy_run_store import SQLAlchemyRunStore
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_round_trip_zero_diff(tmp_path: Any) -> None:
+    """Save then load a checkpoint and assert zero structural diff."""
+    store = SQLAlchemyCheckpointStore(
+        db_url=f"sqlite+aiosqlite:///{tmp_path / 'ckpt.db'}"
+    )
+    await store.init_db()
+
+    original = {
+        "run_id": "abc",
+        "state": {"step": 3, "data": [1, 2, 3]},
+        "config": {"nested": {"deep": True}},
+    }
+
+    await store.save_checkpoint("run-rt-1", original)
+    restored = await store.get_checkpoint("run-rt-1")
+
+    diff = DeepDiff(original, restored)
+    assert diff == {}, f"Checkpoint round-trip fidelity violation: {diff}"
+
+
+@pytest.mark.asyncio
+async def test_run_store_round_trip_zero_diff(tmp_path: Any) -> None:
+    """Save then load a run and assert zero structural diff."""
+    store = SQLAlchemyRunStore(
+        db_url=f"sqlite+aiosqlite:///{tmp_path / 'runs.db'}"
+    )
+    await store.init_db()
+
+    original = {
+        "run_id": "run-42",
+        "status": "completed",
+        "result": {"output": "hello", "tokens": [10, 20, 30]},
+        "metadata": {"source": "test", "nested": {"key": "value"}},
+    }
+
+    await store.save_run("run-42", original)
+    restored = await store.get_run("run-42")
+
+    diff = DeepDiff(original, restored)
+    assert diff == {}, f"Run store round-trip fidelity violation: {diff}"
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_round_trip_with_special_types(tmp_path: Any) -> None:
+    """Round-trip with types that commonly cause fidelity issues."""
+    store = SQLAlchemyCheckpointStore(
+        db_url=f"sqlite+aiosqlite:///{tmp_path / 'ckpt2.db'}"
+    )
+    await store.init_db()
+
+    original = {
+        "float_val": 3.14159,
+        "bool_val": True,
+        "null_val": None,
+        "empty_list": [],
+        "empty_dict": {},
+        "nested_list": [[1, 2], [3, 4]],
+    }
+
+    await store.save_checkpoint("run-special", original)
+    restored = await store.get_checkpoint("run-special")
+
+    diff = DeepDiff(original, restored)
+    assert diff == {}, f"Special types round-trip violation: {diff}"

--- a/tests/stores/test_store_round_trip.py
+++ b/tests/stores/test_store_round_trip.py
@@ -6,7 +6,7 @@ for both CheckpointStore and RunStore implementations.
 
 from __future__ import annotations
 
-from typing import Any
+from pathlib import Path
 
 import pytest
 from deepdiff import DeepDiff
@@ -16,7 +16,7 @@ from miniautogen.stores.sqlalchemy_run_store import SQLAlchemyRunStore
 
 
 @pytest.mark.asyncio
-async def test_checkpoint_round_trip_zero_diff(tmp_path: Any) -> None:
+async def test_checkpoint_round_trip_zero_diff(tmp_path: Path) -> None:
     """Save then load a checkpoint and assert zero structural diff."""
     store = SQLAlchemyCheckpointStore(
         db_url=f"sqlite+aiosqlite:///{tmp_path / 'ckpt.db'}"
@@ -37,7 +37,7 @@ async def test_checkpoint_round_trip_zero_diff(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_store_round_trip_zero_diff(tmp_path: Any) -> None:
+async def test_run_store_round_trip_zero_diff(tmp_path: Path) -> None:
     """Save then load a run and assert zero structural diff."""
     store = SQLAlchemyRunStore(
         db_url=f"sqlite+aiosqlite:///{tmp_path / 'runs.db'}"
@@ -59,7 +59,7 @@ async def test_run_store_round_trip_zero_diff(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_checkpoint_round_trip_with_special_types(tmp_path: Any) -> None:
+async def test_checkpoint_round_trip_with_special_types(tmp_path: Path) -> None:
     """Round-trip with types that commonly cause fidelity issues."""
     store = SQLAlchemyCheckpointStore(
         db_url=f"sqlite+aiosqlite:///{tmp_path / 'ckpt2.db'}"


### PR DESCRIPTION
## Summary
- `assert_no_mutation` helper in `tests/conftest.py` using DeepDiff
- 8 immutability tests for ExecutionEvent and RunContext
- 3 store round-trip fidelity tests
- 3 known violations tracked as `xfail(strict=True)` for WS2
- Updated ruff/mypy targets to py311
- Pinned deepdiff with ceiling (`>=7.0.0,<9.0.0`)

## Test plan
- [ ] `pytest tests/core/contracts/test_immutability.py` — 5 pass, 3 xfail
- [ ] `pytest tests/stores/test_store_round_trip.py` — 3 pass
- [ ] `ruff check` clean

## Review findings addressed
- WS1-H2: ruff/mypy targets updated to py311
- WS1-M1: `ignore_order=False` default
- WS1-M2: `tmp_path: Path` type annotation
- WS1-M4: deepdiff ceiling pin
- WS1-L1: ruff import ordering fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)