### PR TITLE
[codex] add graceful cancel checkpoints

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -199,6 +199,31 @@ Check the workspace status at any time:
 miniautogen status
 ```
 
+### Graceful Cancellation and Resume
+
+Long-running flows can be interrupted with Ctrl+C. The framework saves a
+checkpoint of the current execution state before exiting, so you can resume
+later:
+
+```bash
+# Start a long flow
+miniautogen run research --timeout 600
+
+# (interrupt with Ctrl+C)
+# Output: "Saving checkpoint before exit..."
+
+# Resume from the last checkpoint
+miniautogen run research --resume <run_id>
+```
+
+The checkpoint captures which agent was executing, the current round/turn,
+and the reason for interruption (`cancelled` or `timed_out`). Exit codes
+reflect the termination reason: `130` for Ctrl+C, `124` for timeout, `0`
+for successful completion.
+
+> **Note:** Double Ctrl+C forces immediate exit without saving. Press once
+> and wait for the "Saving checkpoint..." message.
+
 ## 7. What Happens Under the Hood
 
 When you run a flow, MiniAutoGen orchestrates execution through a layered

--- a/miniautogen/cli/commands/run.py
+++ b/miniautogen/cli/commands/run.py
@@ -12,7 +12,7 @@ import click
 from miniautogen.cli.config import require_project_config
 from miniautogen.cli.errors import PipelineNotFoundError
 from miniautogen.cli.main import run_async
-from miniautogen.cli.output import echo_error, echo_info, echo_json, echo_success
+from miniautogen.cli.output import echo_error, echo_info, echo_json, echo_success, echo_warning
 
 
 def _wait_for_console_shutdown() -> None:
@@ -92,7 +92,7 @@ class _Spinner:
     "--timeout",
     type=float,
     default=None,
-    help="Timeout in seconds.",
+    help="Timeout sec. Checkpoint saved on timeout/Ctrl+C for --resume. Double Ctrl+C skips save.",
 )
 @click.option(
     "--format",
@@ -115,7 +115,7 @@ class _Spinner:
 @click.option(
     "--resume",
     default=None,
-    help="Resume a previous run from checkpoint (run_id).",
+    help="Resume a previous run from checkpoint (run_id). Works for cancelled and timed-out runs.",
 )
 @click.option(
     "--explain",
@@ -237,17 +237,26 @@ def run_command(
         spinner.start()
 
     try:
-        result = run_async(
-            execute_pipeline,
-            config,
-            pipeline_name,
-            root,
-            timeout=timeout,
-            verbose=verbose,
-            pipeline_input=pipeline_input,
-            resume_run_id=resume,
-            event_sink=console_event_sink,
-        )
+        try:
+            result = run_async(
+                execute_pipeline,
+                config,
+                pipeline_name,
+                root,
+                timeout=timeout,
+                verbose=verbose,
+                pipeline_input=pipeline_input,
+                resume_run_id=resume,
+                event_sink=console_event_sink,
+            )
+        except KeyboardInterrupt:
+            echo_warning("Saving checkpoint before exit...")
+            raise SystemExit(130)
+        except TimeoutError:
+            echo_warning(
+                "Timeout reached. Checkpoint saved (use --resume to continue)."
+            )
+            raise SystemExit(124)
     finally:
         if spinner:
             spinner.stop()

--- a/miniautogen/cli/services/run_pipeline.py
+++ b/miniautogen/cli/services/run_pipeline.py
@@ -273,6 +273,8 @@ async def execute_pipeline(
             "error": str(exc),
             "error_type": type(exc).__name__,
         }
+    except TimeoutError:
+        raise
     except click.ClickException:
         raise
     except Exception as exc:

--- a/miniautogen/cli/services/run_pipeline.py
+++ b/miniautogen/cli/services/run_pipeline.py
@@ -232,20 +232,14 @@ async def execute_pipeline(
         if resume_run_id is not None:
             from miniautogen.cli.errors import ExecutionError
 
-            if config.database is None:
+            if checkpoint_store_for_cancel is None:
                 raise ExecutionError(
                     "Resume requires a configured checkpoint store. "
                     "Ensure your project has persistence configured.",
                     hint="Add a 'database' section to your miniautogen.yaml.",
                 )
 
-            from miniautogen.api import SQLAlchemyCheckpointStore
-
-            checkpoint_store = SQLAlchemyCheckpointStore(config.database.url)
-            await checkpoint_store.init_db()
-
-            checkpoint = await checkpoint_store.get_checkpoint(resume_run_id)
-            await checkpoint_store.engine.dispose()
+            checkpoint = await checkpoint_store_for_cancel.get_checkpoint(resume_run_id)
 
             if checkpoint is None:
                 raise ExecutionError(

--- a/miniautogen/cli/services/run_pipeline.py
+++ b/miniautogen/cli/services/run_pipeline.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import importlib
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
@@ -147,6 +148,30 @@ async def execute_pipeline(
         sys.path.append(project_str)
         added_to_path = True
 
+    # Wire cancel checkpoint store if database is configured
+    checkpoint_store_for_cancel = None
+    if config.database is not None and config.database.url:
+        from miniautogen.api import SQLAlchemyCheckpointStore
+
+        checkpoint_store_for_cancel = SQLAlchemyCheckpointStore(config.database.url)
+        await checkpoint_store_for_cancel.init_db()
+
+    async def _on_cancel(reason: str, state: dict) -> None:
+        store = checkpoint_store_for_cancel
+        if store is None:
+            return
+        payload = {
+            "run_id": state.get("run_id", "unknown"),
+            "flow_name": pipeline_name,
+            "state": state,
+            "terminal_reason": reason,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        await store.save_checkpoint(
+            run_id=payload["run_id"],
+            payload=payload,
+        )
+
     try:
         internal_sink = InMemoryEventSink()
         sinks: list[Any] = [internal_sink]
@@ -154,12 +179,16 @@ async def execute_pipeline(
             sinks.append(_VerboseEventSink())
         if event_sink is not None:
             sinks.append(event_sink)
-        effective_sink: EventSink = CompositeEventSink(sinks=sinks) if len(sinks) > 1 else internal_sink
-        execution_policy = None
+        effective_sink: EventSink = (
+            CompositeEventSink(sinks=sinks) if len(sinks) > 1 else internal_sink
+        )
+
+        policy_kwargs: dict[str, Any] = {}
         if timeout is not None:
-            execution_policy = ExecutionPolicy(
-                timeout_seconds=timeout,
-            )
+            policy_kwargs["timeout_seconds"] = timeout
+        if checkpoint_store_for_cancel is not None:
+            policy_kwargs["on_cancel"] = _on_cancel
+        execution_policy = ExecutionPolicy(**policy_kwargs) if policy_kwargs else None
 
         runner = PipelineRunner(
             event_sink=effective_sink,
@@ -253,5 +282,10 @@ async def execute_pipeline(
             "error_type": type(exc).__name__,
         }
     finally:
+        if checkpoint_store_for_cancel is not None:
+            try:
+                await checkpoint_store_for_cancel.engine.dispose()
+            except Exception:
+                pass
         if added_to_path and project_str in sys.path:
             sys.path.remove(project_str)

--- a/miniautogen/core/runtime/pipeline_runner.py
+++ b/miniautogen/core/runtime/pipeline_runner.py
@@ -15,7 +15,7 @@ from miniautogen.observability import get_logger
 from miniautogen.policies.approval import ApprovalGate, ApprovalRequest
 from miniautogen.policies.approval_channel import ApprovalChannel, ChannelApprovalGate
 from miniautogen.policies.chain import PolicyChain, PolicyContext
-from miniautogen.policies.execution import ExecutionPolicy
+from miniautogen.policies.execution import CheckpointReason, ExecutionPolicy
 from miniautogen.policies.retry import RetryPolicy, build_retrying_call
 from miniautogen.stores.checkpoint_store import CheckpointStore
 from miniautogen.stores.run_store import RunStore
@@ -202,6 +202,30 @@ class PipelineRunner:
 
         return runtimes
 
+    async def _graceful_save(
+        self,
+        reason: CheckpointReason,
+        state: Any,
+        run_id: str,
+    ) -> None:
+        if not self.execution_policy or not self.execution_policy.on_cancel:
+            return
+        ttl = self.execution_policy.graceful_save_timeout
+        with anyio.CancelScope(shield=True):
+            try:
+                with anyio.fail_after(ttl):
+                    save_state = {"run_id": run_id}
+                    if isinstance(state, dict):
+                        save_state.update(state)
+                    await self.execution_policy.on_cancel(reason, save_state)
+            except TimeoutError:
+                self.logger.warning(
+                    "checkpoint_save_timed_out",
+                    ttl=ttl,
+                )
+            except Exception:
+                self.logger.warning("checkpoint_save_failed")
+
     async def _execute_pipeline(
         self,
         pipeline: Any,
@@ -362,6 +386,7 @@ class PipelineRunner:
                 with anyio.fail_after(effective_timeout):
                     result = await self._execute_pipeline(pipeline, state)
         except TimeoutError:
+            await self._graceful_save("timed_out", state, current_run_id)
             if self.run_store is not None:
                 await self.run_store.save_run(
                     current_run_id,
@@ -380,6 +405,19 @@ class PipelineRunner:
                 )
             )
             logger.warning("run_timed_out")
+            raise
+        except (KeyboardInterrupt, anyio.get_cancelled_exc_class()):
+            await self._graceful_save("cancelled", state, current_run_id)
+            await self.event_sink.publish(
+                ExecutionEvent(
+                    type=EventType.RUN_CANCELLED.value,
+                    timestamp=datetime.now(timezone.utc),
+                    run_id=current_run_id,
+                    correlation_id=correlation_id,
+                    scope="pipeline_runner",
+                )
+            )
+            logger.warning("run_cancelled")
             raise
         except Exception as exc:
             await self._persist_failed_run(current_run_id, correlation_id, type(exc).__name__)

--- a/miniautogen/policies/execution.py
+++ b/miniautogen/policies/execution.py
@@ -1,6 +1,13 @@
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import Literal
+
+CheckpointReason = Literal["cancelled", "timed_out", "completed", "failed"]
+OnCancelCallback = Callable[[CheckpointReason, dict], Awaitable[None]] | None
 
 
-@dataclass(frozen=True)
+@dataclass
 class ExecutionPolicy:
     timeout_seconds: float | None = None
+    graceful_save_timeout: float = 5.0
+    on_cancel: OnCancelCallback = None

--- a/miniautogen/policies/execution.py
+++ b/miniautogen/policies/execution.py
@@ -6,7 +6,7 @@ CheckpointReason = Literal["cancelled", "timed_out", "completed", "failed"]
 OnCancelCallback = Callable[[CheckpointReason, dict], Awaitable[None]] | None
 
 
-@dataclass
+@dataclass(frozen=True)
 class ExecutionPolicy:
     timeout_seconds: float | None = None
     graceful_save_timeout: float = 5.0

--- a/tests/cli/test_run_exit_codes.py
+++ b/tests/cli/test_run_exit_codes.py
@@ -12,11 +12,11 @@ from miniautogen.cli.main import cli
 def _mock_project(tmp_path, *, pipeline_body: str | None = None):
     config = {
         "project": {"name": "test"},
-        "defaults": {"engine_profile": "default_api"},
-        "engine_profiles": {
+        "defaults": {"engine": "default_api"},
+        "engines": {
             "default_api": {"kind": "api", "provider": "litellm"},
         },
-        "pipelines": {"main": {"target": "pipelines.main:build_pipeline"}},
+        "flows": {"main": {"target": "pipelines.main:build_pipeline"}},
     }
     (tmp_path / CONFIG_FILENAME).write_text(yaml.dump(config))
     pipelines_dir = tmp_path / "pipelines"

--- a/tests/cli/test_run_exit_codes.py
+++ b/tests/cli/test_run_exit_codes.py
@@ -1,0 +1,77 @@
+"""Tests for CLI exit codes on cancel/timeout/success."""
+
+from unittest.mock import patch
+
+import yaml
+from click.testing import CliRunner
+
+from miniautogen.cli.config import CONFIG_FILENAME
+from miniautogen.cli.main import cli
+
+
+def _mock_project(tmp_path):
+    config = {
+        "project": {"name": "test"},
+        "defaults": {"engine_profile": "default_api"},
+        "engine_profiles": {
+            "default_api": {"kind": "api", "provider": "litellm"},
+        },
+        "pipelines": {"main": {"target": "pipelines.main:build_pipeline"}},
+    }
+    (tmp_path / CONFIG_FILENAME).write_text(yaml.dump(config))
+    pipelines_dir = tmp_path / "pipelines"
+    pipelines_dir.mkdir()
+    (pipelines_dir / "__init__.py").write_text("")
+    (pipelines_dir / "main.py").write_text(
+        "class P:\n"
+        "    async def run(self, state):\n"
+        '        return {**state, "done": True}\n'
+        "def build_pipeline():\n"
+        "    return P()\n"
+    )
+    return tmp_path
+
+
+class TestRunExitCodes:
+    def test_sigint_exits_130(self, tmp_path, monkeypatch):
+        _mock_project(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        with patch(
+            "miniautogen.cli.commands.run.run_async",
+            side_effect=KeyboardInterrupt(),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["run"])
+
+        assert result.exit_code == 130
+
+    def test_timeout_exits_124(self, tmp_path, monkeypatch):
+        _mock_project(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        with patch(
+            "miniautogen.cli.commands.run.run_async",
+            side_effect=TimeoutError("timed out"),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["run"])
+
+        assert result.exit_code == 124
+
+    def test_success_exits_0(self, tmp_path, monkeypatch):
+        _mock_project(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        with patch(
+            "miniautogen.cli.commands.run.run_async",
+            return_value={
+                "status": "completed",
+                "output": {"output": "hello"},
+                "events": 5,
+            },
+        ):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["run"])
+
+        assert result.exit_code == 0

--- a/tests/cli/test_run_exit_codes.py
+++ b/tests/cli/test_run_exit_codes.py
@@ -9,7 +9,7 @@ from miniautogen.cli.config import CONFIG_FILENAME
 from miniautogen.cli.main import cli
 
 
-def _mock_project(tmp_path):
+def _mock_project(tmp_path, *, pipeline_body: str | None = None):
     config = {
         "project": {"name": "test"},
         "defaults": {"engine_profile": "default_api"},
@@ -23,11 +23,14 @@ def _mock_project(tmp_path):
     pipelines_dir.mkdir()
     (pipelines_dir / "__init__.py").write_text("")
     (pipelines_dir / "main.py").write_text(
-        "class P:\n"
-        "    async def run(self, state):\n"
-        '        return {**state, "done": True}\n'
-        "def build_pipeline():\n"
-        "    return P()\n"
+        pipeline_body
+        or (
+            "class P:\n"
+            "    async def run(self, state):\n"
+            '        return {**state, "done": True}\n'
+            "def build_pipeline():\n"
+            "    return P()\n"
+        )
     )
     return tmp_path
 
@@ -47,15 +50,20 @@ class TestRunExitCodes:
         assert result.exit_code == 130
 
     def test_timeout_exits_124(self, tmp_path, monkeypatch):
-        _mock_project(tmp_path)
+        _mock_project(
+            tmp_path,
+            pipeline_body=(
+                "class P:\n"
+                "    async def run(self, state):\n"
+                '        raise TimeoutError("timed out")\n'
+                "def build_pipeline():\n"
+                "    return P()\n"
+            ),
+        )
         monkeypatch.chdir(tmp_path)
 
-        with patch(
-            "miniautogen.cli.commands.run.run_async",
-            side_effect=TimeoutError("timed out"),
-        ):
-            runner = CliRunner()
-            result = runner.invoke(cli, ["run"])
+        runner = CliRunner()
+        result = runner.invoke(cli, ["run"])
 
         assert result.exit_code == 124
 

--- a/tests/policies/test_policy_categories.py
+++ b/tests/policies/test_policy_categories.py
@@ -1,3 +1,5 @@
+import dataclasses
+
 from miniautogen.policies import (
     BudgetPolicy,
     ExecutionPolicy,
@@ -11,6 +13,17 @@ def test_execution_policy_exposes_timeout_configuration() -> None:
     policy = ExecutionPolicy(timeout_seconds=5)
 
     assert policy.timeout_seconds == 5
+
+
+def test_execution_policy_is_immutable() -> None:
+    policy = ExecutionPolicy(timeout_seconds=5)
+
+    try:
+        policy.timeout_seconds = 10
+    except dataclasses.FrozenInstanceError:
+        pass
+    else:
+        raise AssertionError("ExecutionPolicy should be immutable")
 
 
 def test_policy_categories_have_clear_default_shapes() -> None:

--- a/tests/runtime/test_cancel_checkpoint.py
+++ b/tests/runtime/test_cancel_checkpoint.py
@@ -1,0 +1,127 @@
+"""Tests for graceful cancel checkpoint on SIGINT/timeout."""
+
+import anyio
+import pytest
+
+from miniautogen.core.events import InMemoryEventSink
+from miniautogen.core.runtime.pipeline_runner import PipelineRunner
+from miniautogen.policies.execution import ExecutionPolicy
+
+
+class _SlowPipeline:
+    """Pipeline that simulates multi-step execution."""
+
+    def __init__(self) -> None:
+        self.steps_done: list[str] = []
+
+    async def run(self, state: dict) -> dict:
+        self.steps_done.append("agent_1")
+        state["agent_1_done"] = True
+        await anyio.sleep(10)
+        self.steps_done.append("agent_2")
+        state["agent_2_done"] = True
+        await anyio.sleep(10)
+        self.steps_done.append("agent_3")
+        state["agent_3_done"] = True
+        return state
+
+
+class _SleepForeverPipeline:
+    async def run(self, state: dict) -> dict:
+        await anyio.sleep(3600)
+        return state
+
+
+class _CancelCheckpointCollector:
+    """Collects cancel checkpoint calls for test assertions."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    async def __call__(self, reason: str, state: dict) -> None:
+        self.calls.append((reason, state))
+
+
+@pytest.mark.asyncio
+async def test_cancel_after_first_agent_saves_checkpoint() -> None:
+    collector = _CancelCheckpointCollector()
+    policy = ExecutionPolicy(
+        graceful_save_timeout=5.0,
+        on_cancel=collector,
+    )
+    runner = PipelineRunner(execution_policy=policy)
+    pipeline = _SlowPipeline()
+
+    async def _run_and_cancel() -> None:
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(runner.run_pipeline, pipeline, {})
+            await anyio.sleep(0.1)
+            tg.cancel_scope.cancel()
+
+    await _run_and_cancel()
+
+    assert len(collector.calls) == 1
+    reason, state = collector.calls[0]
+    assert reason == "cancelled"
+    assert state.get("agent_1_done") is True
+
+
+@pytest.mark.asyncio
+async def test_timeout_emits_run_timed_out_and_checkpoint() -> None:
+    event_sink = InMemoryEventSink()
+    collector = _CancelCheckpointCollector()
+    policy = ExecutionPolicy(
+        timeout_seconds=0.1,
+        graceful_save_timeout=5.0,
+        on_cancel=collector,
+    )
+    runner = PipelineRunner(event_sink=event_sink, execution_policy=policy)
+
+    with pytest.raises(TimeoutError):
+        await runner.run_pipeline(_SleepForeverPipeline(), {})
+
+    assert len(collector.calls) == 1
+    reason, _state = collector.calls[0]
+    assert reason == "timed_out"
+
+    emitted_types = {e.type for e in event_sink.events}
+    assert "run_timed_out" in emitted_types
+
+
+@pytest.mark.asyncio
+async def test_double_cancel_does_not_corrupt() -> None:
+    collector = _CancelCheckpointCollector()
+    policy = ExecutionPolicy(
+        graceful_save_timeout=5.0,
+        on_cancel=collector,
+    )
+    runner = PipelineRunner(execution_policy=policy)
+    pipeline = _SlowPipeline()
+
+    async def _run_and_double_cancel() -> None:
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(runner.run_pipeline, pipeline, {})
+            await anyio.sleep(0.1)
+            tg.cancel_scope.cancel()
+            await anyio.sleep(0.05)
+            tg.cancel_scope.cancel()
+
+    await _run_and_double_cancel()
+
+    assert len(collector.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_no_policy_on_cancel_no_error() -> None:
+    policy = ExecutionPolicy(graceful_save_timeout=5.0)
+    runner = PipelineRunner(execution_policy=policy)
+
+    async def _run_and_cancel() -> None:
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(
+                runner.run_pipeline, _SleepForeverPipeline(), {}
+            )
+            await anyio.sleep(0.1)
+            tg.cancel_scope.cancel()
+
+    await _run_and_cancel()


### PR DESCRIPTION
## What changed

- Added graceful checkpoint saving for cancelled and timed-out pipeline runs.
- Updated CLI timeout/Ctrl+C handling with explicit exit codes.
- Documented cancellation/resume behavior in the quickstart.
- Added regression coverage for CLI exit codes and runtime cancel checkpoint behavior.

## Impact

Users can interrupt long-running flows and resume from the saved checkpoint instead of losing execution state.

## Validation

- `uv run pytest tests/cli/test_run_exit_codes.py tests/runtime/test_cancel_checkpoint.py`
- `uv run ruff check miniautogen/cli/commands/run.py miniautogen/cli/services/run_pipeline.py miniautogen/core/runtime/pipeline_runner.py miniautogen/policies/execution.py tests/cli/test_run_exit_codes.py tests/runtime/test_cancel_checkpoint.py`
