### PR TITLE
feat: implement per-agent timeouts (Spec 013)

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -318,7 +318,55 @@ docker-compose up
 This starts the API server and web console. See the included `Dockerfile` and
 `docker-compose.yml` for configuration options.
 
-## 10. Next Steps
+## 10. Configurando SLAs por Agente
+
+Spec 013 introduz timeouts em três níveis de granularidade no YAML:
+
+| Precedência | Nível         | Campo              | Exemplo                  |
+|-------------|---------------|--------------------|--------------------------|
+| 1 (maior)   | Por agente    | `agent_timeouts`   | `engenheiro: 60.0`       |
+| 2           | Por round     | `round_timeouts`   | `contribute: 60.0`       |
+| 3           | Do flow       | `--timeout` (CLI)  | `miniautogen run --timeout 120` |
+| 4 (menor)   | Da engine     | `timeout_seconds`  | `timeout_seconds: 300.0` |
+
+```yaml
+# miniautogen.yaml
+flows:
+  especificacao:
+    mode: deliberation
+    participants: [advogado, paralegal, engenheiro]
+    leader: advogado
+
+    # Per-agent: cada agente tem seu próprio SLA
+    agent_timeouts:
+      advogado: 300.0
+      engenheiro: 60.0
+      paralegal: 120.0
+
+    # Per-round: fases da deliberação
+    round_timeouts:
+      contribute: 60.0
+      review: 90.0
+      synthesize: 180.0
+
+    # continue (default): agente silenciosamente ignorado
+    # abort: falha o flow inteiro
+    on_timeout_action: continue
+```
+
+### `continue` vs `abort`
+
+- **`continue`** (default): se o timeout de um agente expirar, a contribuição
+  é marcada como incompleta e o flow prossegue normalmente.
+  Use quando a ausência de um agente não deve bloquear a deliberação.
+- **`abort`**: se o timeout expirar, o `TimeoutError` propaga e encerra o flow
+  com exit code 124. Use quando todas as contribuições são obrigatórias.
+
+> **Leitura complementar:**
+> - [Spec completa](/.specs/per-agent-timeouts.md)
+> - [Graceful Cancel e Checkpoint](/.specs/cancel-checkpoint.md) (interage com save shielded)
+
+## 11. Next Steps
 
 - **`miniautogen dash`** -- launch the TUI dashboard to monitor and manage
   agents, flows, and runs visually.

--- a/examples/config/per-agent-timeouts.yaml
+++ b/examples/config/per-agent-timeouts.yaml
@@ -1,0 +1,36 @@
+# Example: Per-Agent Timeouts (Spec 013)
+# Shows three levels of granularity: agent, round, and flow.
+project:
+  name: per-agent-timeouts-demo
+  version: 0.1.0
+
+defaults:
+  engine: default_api
+
+engines:
+  default_api:
+    provider: openai-compat
+    model: gpt-4o
+    timeout_seconds: 300.0  # Level 4: engine fallback (lowest precedence)
+
+flows:
+  especificacao:
+    mode: deliberation
+    participants: [advogado, paralegal, engenheiro]
+    leader: advogado
+    max_rounds: 3
+
+    # Level 1: per-agent timeouts (highest precedence)
+    agent_timeouts:
+      advogado: 300.0
+      engenheiro: 60.0
+      paralegal: 120.0
+
+    # Level 2: per-round/role timeouts
+    round_timeouts:
+      contribute: 60.0
+      review: 90.0
+      synthesize: 180.0
+
+    # Action when a timeout fires: continue | abort
+    on_timeout_action: continue  # default: continue

--- a/miniautogen/cli/config.py
+++ b/miniautogen/cli/config.py
@@ -14,7 +14,7 @@ DA-9 Terminology Migration:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
 from pydantic import BaseModel, Field, model_validator
@@ -119,6 +119,11 @@ class FlowConfig(BaseModel):
     prompts: dict[str, str] = Field(default_factory=dict)
     response_schema: str | None = None  # Python dotted path for structured format
 
+    # Per-agent timeout fields (Spec 013)
+    agent_timeouts: dict[str, float] = Field(default_factory=dict)
+    round_timeouts: dict[str, float] = Field(default_factory=dict)
+    on_timeout_action: Literal["continue", "abort"] = "continue"
+
     @model_validator(mode="after")
     def validate_flow_config(self) -> "FlowConfig":
         if not self.target and not self.mode:
@@ -144,8 +149,8 @@ class FlowConfig(BaseModel):
             )
         if self.response_format == "structured" and not self.response_schema:
             raise ValueError(
-                "response_format='structured' requires 'response_schema' "
-                "(Python dotted path to Pydantic model)"
+                f"response_format='structured' requires 'response_schema' "
+                f"(Python dotted path to Pydantic model)"
             )
         if self.response_schema:
             allowed_prefixes = ("miniautogen.",)
@@ -153,6 +158,29 @@ class FlowConfig(BaseModel):
                 raise ValueError(
                     f"response_schema must start with 'miniautogen.', "
                     f"got '{self.response_schema}'"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def validate_timeout_values(self) -> "FlowConfig":
+        for k, v in self.agent_timeouts.items():
+            if v < 1.0:
+                raise ValueError(
+                    f"agent_timeouts[{k!r}] must be >= 1.0 (got {v})"
+                )
+        for k, v in self.round_timeouts.items():
+            if v < 1.0:
+                raise ValueError(
+                    f"round_timeouts[{k!r}] must be >= 1.0 (got {v})"
+                )
+        for agent_id in self.agent_timeouts:
+            if self.participants and agent_id not in self.participants:
+                import warnings
+                warnings.warn(
+                    f"agent_timeouts has unknown agent {agent_id!r} "
+                    f"(not in participants {self.participants})",
+                    UserWarning,
+                    stacklevel=2,
                 )
         return self
 

--- a/miniautogen/core/contracts/__init__.py
+++ b/miniautogen/core/contracts/__init__.py
@@ -48,6 +48,7 @@ from .runtime_interceptor import RuntimeInterceptor
 from .skill_spec import SkillSpec
 from .store import StoreProtocol
 from .supervision import StepSupervision, SupervisionDecision
+from .timeout_resolution import ResolvedTimeout, TimeoutSource, resolve_timeout
 from .tool import ToolProtocol, ToolResult
 from .tool_spec import ToolSpec
 
@@ -90,8 +91,11 @@ __all__ = [
     "PeerReview",
     "ResearchOutput",
     "Review",
+    "ResolvedTimeout",
     "RouterDecision",
     "RunContext",
+    "TimeoutSource",
+    "resolve_timeout",
     "RunResult",
     "RunStatus",
     "RuntimeInterceptor",

--- a/miniautogen/core/contracts/timeout_resolution.py
+++ b/miniautogen/core/contracts/timeout_resolution.py
@@ -1,0 +1,32 @@
+"""Timeout resolution with 4-level precedence: agent > round > flow > engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+TimeoutSource = Literal["agent", "round", "flow", "engine"]
+
+
+@dataclass(frozen=True)
+class ResolvedTimeout:
+    seconds: float
+    source: TimeoutSource
+
+
+def resolve_timeout(
+    *,
+    agent_id: str,
+    round_name: str | None,
+    agent_timeouts: dict[str, float],
+    round_timeouts: dict[str, float],
+    flow_timeout: float | None,
+    engine_timeout: float,
+) -> ResolvedTimeout:
+    if agent_id in agent_timeouts:
+        return ResolvedTimeout(agent_timeouts[agent_id], "agent")
+    if round_name and round_name in round_timeouts:
+        return ResolvedTimeout(round_timeouts[round_name], "round")
+    if flow_timeout is not None:
+        return ResolvedTimeout(flow_timeout, "flow")
+    return ResolvedTimeout(engine_timeout, "engine")

--- a/miniautogen/core/events/types.py
+++ b/miniautogen/core/events/types.py
@@ -90,6 +90,9 @@ class EventType(str, Enum):
     # Run state machine events
     RUN_STATE_CHANGED = "run_state_changed"
 
+    # Agent turn timeout events
+    AGENT_TURN_TIMED_OUT = "agent_turn_timed_out"
+
     # Approval channel events (decoupled human-in-the-loop)
     APPROVAL_CHANNEL_SUBMITTED = "approval_channel_submitted"
     APPROVAL_CHANNEL_RESOLVED = "approval_channel_resolved"

--- a/miniautogen/core/runtime/agentic_loop_runtime.py
+++ b/miniautogen/core/runtime/agentic_loop_runtime.py
@@ -36,6 +36,7 @@ from miniautogen.core.runtime.flow_supervisor import FlowSupervisor
 from miniautogen.core.runtime.pipeline_runner import PipelineRunner
 from miniautogen.observability import get_logger
 from miniautogen.policies.effect import EffectPolicy
+from miniautogen.policies.timeout_policy import TimeoutPolicy
 
 _SCOPE = "agentic_loop_runtime"
 
@@ -55,10 +56,12 @@ class AgenticLoopRuntime:
         runner: PipelineRunner,
         agent_registry: dict[str, Any] | None = None,
         effect_policy: EffectPolicy | None = None,
+        timeout_policy: TimeoutPolicy | None = None,
     ) -> None:
         self._runner = runner
         self._registry = agent_registry or {}
         self._logger = get_logger(__name__)
+        self._timeout_policy = timeout_policy
 
         self._effect_interceptor: Any = None
         if effect_policy is not None:
@@ -137,9 +140,23 @@ class AgenticLoopRuntime:
                         {"sender": m.sender_id, "content": m.content}
                         for m in conversation.messages
                     ]
-                    decision: RouterDecision = await router_agent.route(
-                        history_for_router
-                    )
+                    decision: RouterDecision | None = None
+                    if self._timeout_policy is not None:
+                        async with self._timeout_policy.scope_for_turn(
+                            agent_id=plan.router_agent,
+                            round_name="route",
+                            emit=self._emit_timeout_event,
+                        ):
+                            decision = await router_agent.route(
+                                history_for_router
+                            )
+                    else:
+                        decision = await router_agent.route(
+                            history_for_router
+                        )
+                    if decision is None:
+                        stop_reason = LoopStopReason.TIMEOUT
+                        break
                     routing_history.append(decision)
 
                     # Emit ROUTER_DECISION
@@ -201,10 +218,24 @@ class AgenticLoopRuntime:
 
                     while True:
                         try:
-                            reply = await agent.reply(
-                                last_message,
-                                {"run_id": run_id, "turn": state.turn_count},
-                            )
+                            reply = None
+                            if self._timeout_policy is not None:
+                                async with self._timeout_policy.scope_for_turn(
+                                    agent_id=agent_id,
+                                    round_name="reply",
+                                    emit=self._emit_timeout_event,
+                                ):
+                                    reply = await agent.reply(
+                                        last_message,
+                                        {"run_id": run_id, "turn": state.turn_count},
+                                    )
+                            else:
+                                reply = await agent.reply(
+                                    last_message,
+                                    {"run_id": run_id, "turn": state.turn_count},
+                                )
+                            if reply is None:
+                                break
                             if restart_count > 0:
                                 await supervisor.emit_retry_succeeded(
                                     step_id=step_id,
@@ -342,3 +373,15 @@ class AgenticLoopRuntime:
             payload=payload or {},
         )
         await self._runner.event_sink.publish(event)
+
+    async def _emit_timeout_event(self, event_type: str, **payload: object) -> None:
+        """Emit a timeout event through the runner's event sink.
+        Matches the EmitCallable signature expected by TimeoutPolicy."""
+        await self._runner.event_sink.publish(
+            ExecutionEvent(
+                type=event_type,
+                timestamp=datetime.now(timezone.utc),
+                scope=_SCOPE,
+                payload=payload,
+            )
+        )

--- a/miniautogen/core/runtime/deliberation_runtime.py
+++ b/miniautogen/core/runtime/deliberation_runtime.py
@@ -38,6 +38,7 @@ from miniautogen.core.runtime.flow_supervisor import FlowSupervisor
 from miniautogen.core.runtime.pipeline_runner import PipelineRunner
 from miniautogen.observability import get_logger
 from miniautogen.policies.effect import EffectPolicy
+from miniautogen.policies.timeout_policy import TimeoutPolicy
 
 _SCOPE = "deliberation_runtime"
 
@@ -56,10 +57,12 @@ class DeliberationRuntime:
         runner: PipelineRunner,
         agent_registry: dict[str, Any] | None = None,
         effect_policy: EffectPolicy | None = None,
+        timeout_policy: TimeoutPolicy | None = None,
     ) -> None:
         self._runner = runner
         self._registry: dict[str, Any] = agent_registry or {}
         self._logger = get_logger(__name__)
+        self._timeout_policy = timeout_policy
 
         self._effect_interceptor: Any = None
         if effect_policy is not None:
@@ -159,7 +162,18 @@ class DeliberationRuntime:
 
                 while True:
                     try:
-                        output = await agent.contribute(plan.topic)
+                        output = None
+                        if self._timeout_policy is not None:
+                            async with self._timeout_policy.scope_for_turn(
+                                agent_id=participant_name,
+                                round_name="contribute",
+                                emit=self._emit_timeout_event,
+                            ):
+                                output = await agent.contribute(plan.topic)
+                        else:
+                            output = await agent.contribute(plan.topic)
+                        if output is None:
+                            break
                         contributions.append(output)
                         logger.info(
                             "contribution_collected",
@@ -215,7 +229,10 @@ class DeliberationRuntime:
                             continue
 
                         # STOP or ESCALATE → fail the deliberation
-                        error_msg = f"Agent '{participant_name}' failed during contribution: {type(exc).__name__}"
+                        error_msg = (
+                            f"Agent '{participant_name}' failed during "
+                            f"contribution: {type(exc).__name__}"
+                        )
                         logger.error(
                             "contribution_failed",
                             participant=participant_name,
@@ -248,9 +265,22 @@ class DeliberationRuntime:
 
                     while True:
                         try:
-                            review = await agent.review(
-                                contribution.role_name, contribution
-                            )
+                            review = None
+                            if self._timeout_policy is not None:
+                                async with self._timeout_policy.scope_for_turn(
+                                    agent_id=participant_name,
+                                    round_name="review",
+                                    emit=self._emit_timeout_event,
+                                ):
+                                    review = await agent.review(
+                                        contribution.role_name, contribution
+                                    )
+                            else:
+                                review = await agent.review(
+                                    contribution.role_name, contribution
+                                )
+                            if review is None:
+                                break
                             reviews.append(review)
                             logger.info(
                                 "peer_review_collected",
@@ -272,7 +302,9 @@ class DeliberationRuntime:
                             if supervision is None:
                                 error_msg = (
                                     f"Agent '{participant_name}' failed during "
-                                    f"peer review of '{contribution.role_name}': {type(exc).__name__}"
+                                    "peer review of "
+                                    f"'{contribution.role_name}': "
+                                    f"{type(exc).__name__}"
                                 )
                                 logger.error(
                                     "peer_review_failed",
@@ -340,16 +372,32 @@ class DeliberationRuntime:
 
             # --- phase 3: leader consolidation ---
             try:
-                state = await leader_agent.consolidate(
-                    plan.topic, contributions, reviews
-                )
+                state = None
+                if self._timeout_policy is not None:
+                    async with self._timeout_policy.scope_for_turn(
+                        agent_id=leader_name,
+                        round_name="synthesize",
+                        emit=self._emit_timeout_event,
+                    ):
+                        state = await leader_agent.consolidate(
+                            plan.topic, contributions, reviews
+                        )
+                else:
+                    state = await leader_agent.consolidate(
+                        plan.topic, contributions, reviews
+                    )
+                if state is None:
+                    state = DeliberationState()
                 logger.info(
                     "consolidation_complete",
                     leader=leader_name,
                     round_num=round_num + 1,
                 )
             except Exception as exc:
-                error_msg = f"Leader '{leader_name}' failed during consolidation: {type(exc).__name__}"
+                error_msg = (
+                    f"Leader '{leader_name}' failed during "
+                    f"consolidation: {type(exc).__name__}"
+                )
                 logger.error(
                     "consolidation_failed",
                     leader=leader_name,
@@ -383,13 +431,41 @@ class DeliberationRuntime:
 
         # --- phase 5: final document (3C) ---
         try:
-            final_doc = await leader_agent.produce_final_document(
-                state, contributions
-            )
+            final_doc = None
+            if self._timeout_policy is not None:
+                async with self._timeout_policy.scope_for_turn(
+                    agent_id=leader_name,
+                    round_name="produce_final_document",
+                    emit=self._emit_timeout_event,
+                ):
+                    final_doc = await leader_agent.produce_final_document(
+                        state, contributions
+                    )
+            else:
+                final_doc = await leader_agent.produce_final_document(
+                    state, contributions
+                )
+            if final_doc is None:
+                error_msg = f"Leader '{leader_name}' timed out producing final document"
+                logger.error("final_document_timeout", leader=leader_name)
+                await self._emit(
+                    event_type=_EVT_FAILED,
+                    run_id=context.run_id,
+                    correlation_id=correlation_id,
+                    payload={"error": error_msg},
+                )
+                return RunResult(
+                    run_id=context.run_id,
+                    status=RunStatus.FAILED,
+                    error=error_msg,
+                )
             rendered = render_final_document_markdown(final_doc)
             logger.info("final_document_produced", leader=leader_name)
         except Exception as exc:
-            error_msg = f"Leader '{leader_name}' failed producing final document: {type(exc).__name__}"
+            error_msg = (
+                f"Leader '{leader_name}' failed producing final "
+                f"document: {type(exc).__name__}"
+            )
             logger.error(
                 "final_document_failed",
                 leader=leader_name,
@@ -451,5 +527,17 @@ class DeliberationRuntime:
                 correlation_id=correlation_id,
                 scope=_SCOPE,
                 payload=payload or {},
+            )
+        )
+
+    async def _emit_timeout_event(self, event_type: str, **payload: object) -> None:
+        """Emit a timeout event through the runner's event sink.
+        Matches the EmitCallable signature expected by TimeoutPolicy."""
+        await self._runner.event_sink.publish(
+            ExecutionEvent(
+                type=event_type,
+                timestamp=datetime.now(timezone.utc),
+                scope=_SCOPE,
+                payload=payload,
             )
         )

--- a/miniautogen/core/runtime/deliberation_runtime.py
+++ b/miniautogen/core/runtime/deliberation_runtime.py
@@ -456,7 +456,7 @@ class DeliberationRuntime:
                 )
                 return RunResult(
                     run_id=context.run_id,
-                    status=RunStatus.FAILED,
+                    status=RunStatus.TIMED_OUT,
                     error=error_msg,
                 )
             rendered = render_final_document_markdown(final_doc)

--- a/miniautogen/core/runtime/pipeline_runner.py
+++ b/miniautogen/core/runtime/pipeline_runner.py
@@ -526,15 +526,27 @@ class PipelineRunner:
             for rt in runtimes.values():
                 await rt.initialize()
 
-            # 4. Build coordination plan + runtime
+            # 4. Build TimeoutPolicy from FlowConfig + EngineConfig
+            timeout_policy = _build_timeout_policy(
+                flow_config=flow_config,
+                config=config,
+                flow_timeout=(
+                    self.execution_policy.timeout_seconds
+                    if self.execution_policy is not None
+                    else None
+                ),
+            )
+
+            # 5. Build coordination plan + runtime
             plan, coordination_runtime = _build_coordination_from_config(
                 flow_config=flow_config,
                 runner=self,
                 agent_registry=runtimes,
                 input_text=input_text,
+                timeout_policy=timeout_policy,
             )
 
-            # 5. Build RunContext for the coordination run
+            # 6. Build RunContext for the coordination run
             run_context = RunContext(
                 run_id=run_id,
                 started_at=datetime.now(timezone.utc),
@@ -558,7 +570,7 @@ class PipelineRunner:
             )
             logger.info("run_from_config_started", mode=flow_config.mode)
 
-            # 6. Execute coordination
+            # 7. Execute coordination
             agents_list = [
                 runtimes[name] for name in flow_config.participants
             ]
@@ -566,7 +578,7 @@ class PipelineRunner:
                 agents_list, run_context, plan,
             )
 
-            # Emit RUN_FINISHED
+            # 8. Emit RUN_FINISHED
             await self.event_sink.publish(
                 ExecutionEvent(
                     type=EventType.RUN_FINISHED.value,
@@ -651,12 +663,41 @@ async def _build_prompt_from_spec(
     return "\n".join(parts) if parts else None
 
 
+def _build_timeout_policy(
+    *,
+    flow_config: FlowConfig,
+    config: WorkspaceConfig,
+    flow_timeout: float | None = None,
+) -> Any:
+    """Build a TimeoutPolicy from FlowConfig + engine defaults."""
+    from miniautogen.policies.timeout_policy import TimeoutPolicy
+
+    engine_timeout = _resolve_engine_timeout(config)
+    return TimeoutPolicy(
+        agent_timeouts=flow_config.agent_timeouts,
+        round_timeouts=flow_config.round_timeouts,
+        flow_timeout=flow_timeout,
+        engine_timeout=engine_timeout,
+        on_timeout_action=flow_config.on_timeout_action,
+    )
+
+
+def _resolve_engine_timeout(config: WorkspaceConfig) -> float:
+    """Resolve the default engine's timeout_seconds (fallback: 120.0)."""
+    engine_name = config.defaults.engine
+    engine = config.engines.get(engine_name)
+    if engine is not None:
+        return engine.timeout_seconds
+    return 120.0
+
+
 def _build_coordination_from_config(
     *,
     flow_config: FlowConfig,
     runner: PipelineRunner,
     agent_registry: dict[str, Any],
     input_text: str | None = None,
+    timeout_policy: Any | None = None,
 ) -> tuple[Any, Any]:
     """Map a FlowConfig to a (plan, coordination_runtime) tuple.
 
@@ -719,6 +760,7 @@ def _build_coordination_from_config(
             runner=runner,
             agent_registry=agent_registry,
             checkpoint_manager=checkpoint_manager,
+            timeout_policy=timeout_policy,
         )
         return plan, coordination_runtime
 
@@ -732,6 +774,7 @@ def _build_coordination_from_config(
         coordination_runtime = DeliberationRuntime(
             runner=runner,
             agent_registry=agent_registry,
+            timeout_policy=timeout_policy,
         )
         return plan, coordination_runtime
 
@@ -744,6 +787,7 @@ def _build_coordination_from_config(
         coordination_runtime = AgenticLoopRuntime(
             runner=runner,
             agent_registry=agent_registry,
+            timeout_policy=timeout_policy,
         )
         return plan, coordination_runtime
 

--- a/miniautogen/core/runtime/workflow_runtime.py
+++ b/miniautogen/core/runtime/workflow_runtime.py
@@ -30,6 +30,11 @@ from miniautogen.core.runtime.flow_supervisor import FlowSupervisor
 from miniautogen.core.runtime.pipeline_runner import PipelineRunner
 from miniautogen.observability import get_logger
 from miniautogen.policies.effect import EffectPolicy
+from miniautogen.policies.timeout_policy import TimeoutPolicy
+
+
+class WorkflowAgentTimeout(Exception):
+    """Raised internally when a workflow agent turn times out."""
 
 
 class WorkflowRuntime:
@@ -47,11 +52,13 @@ class WorkflowRuntime:
         agent_registry: dict[str, Any] | None = None,
         checkpoint_manager: CheckpointManager | None = None,
         effect_policy: EffectPolicy | None = None,
+        timeout_policy: TimeoutPolicy | None = None,
     ) -> None:
         self._runner = runner
         self._registry = agent_registry or {}
         self._checkpoint_manager = checkpoint_manager
         self._logger = get_logger(__name__)
+        self._timeout_policy = timeout_policy
 
         self._effect_interceptor: Any = None
         if effect_policy is not None:
@@ -92,7 +99,11 @@ class WorkflowRuntime:
             return RunResult(run_id=run_id, status=RunStatus.FAILED, error=validation_error)
 
         # --- Emit RUN_STARTED ---
-        await self._emit(event_type=EventType.RUN_STARTED.value, run_id=run_id, correlation_id=correlation_id)
+        await self._emit(
+            event_type=EventType.RUN_STARTED.value,
+            run_id=run_id,
+            correlation_id=correlation_id,
+        )
         logger.info("workflow_started", fan_out=plan.fan_out, steps=len(plan.steps))
 
         try:
@@ -112,6 +123,25 @@ class WorkflowRuntime:
                 final_output = outputs
 
         except BaseException as exc:
+            if self._is_agent_timeout(exc):
+                try:
+                    await self._emit(
+                        event_type=EventType.RUN_TIMED_OUT.value,
+                        run_id=run_id,
+                        correlation_id=correlation_id,
+                        payload={"error": "agent_timeout"},
+                    )
+                except Exception:
+                    logger.warning(
+                        "failed_to_emit_timeout_event",
+                        original_error="agent_timeout",
+                    )
+                logger.warning("workflow_timed_out", error="agent_timeout")
+                return RunResult(
+                    run_id=run_id,
+                    status=RunStatus.TIMED_OUT,
+                    error="agent_timeout",
+                )
             if isinstance(exc, BaseExceptionGroup):
                 error_messages = [type(e).__name__ for e in exc.exceptions]
                 combined_error = "; ".join(error_messages)
@@ -132,7 +162,11 @@ class WorkflowRuntime:
             return RunResult(run_id=run_id, status=RunStatus.FAILED, error=combined_error)
 
         # --- Emit RUN_FINISHED ---
-        await self._emit(event_type=EventType.RUN_FINISHED.value, run_id=run_id, correlation_id=correlation_id)
+        await self._emit(
+            event_type=EventType.RUN_FINISHED.value,
+            run_id=run_id,
+            correlation_id=correlation_id,
+        )
         logger.info("workflow_finished")
 
         return RunResult(run_id=run_id, status=RunStatus.FINISHED, output=final_output)
@@ -149,6 +183,13 @@ class WorkflowRuntime:
         if plan.synthesis_agent is not None and plan.synthesis_agent not in self._registry:
             return f"Synthesis agent '{plan.synthesis_agent}' not found in registry"
         return None
+
+    def _is_agent_timeout(self, exc: BaseException) -> bool:
+        if isinstance(exc, WorkflowAgentTimeout):
+            return True
+        if isinstance(exc, BaseExceptionGroup):
+            return any(self._is_agent_timeout(inner) for inner in exc.exceptions)
+        return False
 
     async def _run_sequential(
         self,
@@ -339,6 +380,31 @@ class WorkflowRuntime:
     async def _invoke_agent(self, agent_id: str, input_data: Any) -> Any:
         """Call an agent from the registry. Supports both process() and __call__."""
         agent = self._registry[agent_id]
+        if self._timeout_policy is not None:
+            result = None
+            timed_out = False
+
+            async def emit_timeout_event(
+                event_type: str,
+                **payload: object,
+            ) -> None:
+                nonlocal timed_out
+                if event_type == EventType.AGENT_TURN_TIMED_OUT.value:
+                    timed_out = True
+                await self._emit_timeout_event(event_type, **payload)
+
+            async with self._timeout_policy.scope_for_turn(
+                agent_id=agent_id,
+                round_name=None,
+                emit=emit_timeout_event,
+            ):
+                if hasattr(agent, "process"):
+                    result = await agent.process(input_data)
+                else:
+                    result = await agent(input_data)
+            if timed_out:
+                raise WorkflowAgentTimeout("agent_timeout")
+            return result
         if hasattr(agent, "process"):
             return await agent.process(input_data)
         return await agent(input_data)
@@ -361,3 +427,15 @@ class WorkflowRuntime:
             payload=payload or {},
         )
         await self._runner.event_sink.publish(event)
+
+    async def _emit_timeout_event(self, event_type: str, **payload: object) -> None:
+        """Emit a timeout event through the runner's event sink.
+        Matches the EmitCallable signature expected by TimeoutPolicy."""
+        await self._runner.event_sink.publish(
+            ExecutionEvent(
+                type=event_type,
+                timestamp=datetime.now(timezone.utc),
+                scope="workflow_runtime",
+                payload=payload,
+            )
+        )

--- a/miniautogen/core/runtime/workflow_runtime.py
+++ b/miniautogen/core/runtime/workflow_runtime.py
@@ -185,7 +185,7 @@ class WorkflowRuntime:
         return None
 
     def _is_agent_timeout(self, exc: BaseException) -> bool:
-        if isinstance(exc, WorkflowAgentTimeout):
+        if isinstance(exc, (WorkflowAgentTimeout, TimeoutError)):
             return True
         if isinstance(exc, BaseExceptionGroup):
             return any(self._is_agent_timeout(inner) for inner in exc.exceptions)

--- a/miniautogen/policies/__init__.py
+++ b/miniautogen/policies/__init__.py
@@ -21,6 +21,7 @@ from miniautogen.policies.permission import (
 )
 from miniautogen.policies.retry import RetryPolicy, build_retrying_call
 from miniautogen.policies.timeout import TimeoutScope
+from miniautogen.policies.timeout_policy import TimeoutPolicy
 from miniautogen.policies.validation import (
     ValidationError,
     ValidationPolicy,
@@ -46,6 +47,7 @@ __all__ = [
     "PolicyEvaluator",
     "PolicyResult",
     "RetryPolicy",
+    "TimeoutPolicy",
     "TimeoutScope",
     "ValidationError",
     "ValidationPolicy",

--- a/miniautogen/policies/timeout_policy.py
+++ b/miniautogen/policies/timeout_policy.py
@@ -65,7 +65,7 @@ class TimeoutPolicy:
                 yield resolved
         except TimeoutError:
             await emit(
-                "agent_turn_timed_out",
+                EventType.AGENT_TURN_TIMED_OUT.value,
                 agent_id=agent_id,
                 round_name=round_name,
                 applied_timeout=resolved.seconds,

--- a/miniautogen/policies/timeout_policy.py
+++ b/miniautogen/policies/timeout_policy.py
@@ -1,0 +1,81 @@
+"""TimeoutPolicy — wraps agent turns in anyio.fail_after scopes.
+
+Emits agent_turn_timed_out on expiration. Supports 'continue' (default)
+and 'abort' on_timeout_action. Precedence: agent > round > flow > engine.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Callable
+
+import anyio
+import structlog
+
+from miniautogen.core.contracts.timeout_resolution import (
+    ResolvedTimeout,
+    resolve_timeout,
+)
+
+logger = structlog.get_logger()
+
+EmitCallable = Callable[..., Any]
+
+
+class TimeoutPolicy:
+    """Lateral policy that wraps each agent turn in a fail_after scope.
+
+    Subscribes to agent_turn_started; opens a CancelScope; on expiration,
+    cancels the turn and emits agent_turn_timed_out.
+    """
+
+    def __init__(
+        self,
+        *,
+        agent_timeouts: dict[str, float],
+        round_timeouts: dict[str, float],
+        flow_timeout: float | None,
+        engine_timeout: float,
+        on_timeout_action: str = "continue",
+    ) -> None:
+        self._agent_timeouts = agent_timeouts
+        self._round_timeouts = round_timeouts
+        self._flow_timeout = flow_timeout
+        self._engine_timeout = engine_timeout
+        self._on_timeout_action = on_timeout_action
+
+    @asynccontextmanager
+    async def scope_for_turn(
+        self,
+        *,
+        agent_id: str,
+        round_name: str | None,
+        emit: EmitCallable,
+    ) -> AsyncIterator[ResolvedTimeout]:
+        resolved = resolve_timeout(
+            agent_id=agent_id,
+            round_name=round_name,
+            agent_timeouts=self._agent_timeouts,
+            round_timeouts=self._round_timeouts,
+            flow_timeout=self._flow_timeout,
+            engine_timeout=self._engine_timeout,
+        )
+        try:
+            with anyio.fail_after(resolved.seconds):
+                yield resolved
+        except TimeoutError:
+            await emit(
+                "agent_turn_timed_out",
+                agent_id=agent_id,
+                round_name=round_name,
+                applied_timeout=resolved.seconds,
+                source=resolved.source,
+            )
+            if self._on_timeout_action == "abort":
+                raise
+            logger.warning(
+                "timeout_policy.continue_after_timeout",
+                agent_id=agent_id,
+                round_name=round_name,
+                applied=resolved.seconds,
+            )

--- a/tests/cli/test_flow_config_timeouts.py
+++ b/tests/cli/test_flow_config_timeouts.py
@@ -1,0 +1,66 @@
+"""Tests for FlowConfig timeout fields — Spec 013."""
+
+import warnings
+
+import pytest
+from pydantic import ValidationError
+
+from miniautogen.cli.config import FlowConfig
+
+
+class TestFlowConfigTimeouts:
+    def test_no_timeout_fields_is_valid(self) -> None:
+        """YAML without agent_timeouts/round_timeouts validates."""
+        config = FlowConfig(
+            mode="deliberation",
+            participants=["advogado", "engenheiro"],
+            leader="advogado",
+        )
+        assert config.agent_timeouts == {}
+        assert config.round_timeouts == {}
+        assert config.on_timeout_action == "continue"
+
+    def test_agent_timeouts_dict_accepted(self) -> None:
+        """dict of {'engenheiro': 60.0} is accepted."""
+        config = FlowConfig(
+            mode="deliberation",
+            participants=["advogado", "engenheiro"],
+            leader="advogado",
+            agent_timeouts={"engenheiro": 60.0},
+        )
+        assert config.agent_timeouts["engenheiro"] == 60.0
+
+    def test_timeout_below_one_second_rejected(self) -> None:
+        """Values < 1.0 raise ValidationError."""
+        with pytest.raises(ValidationError):
+            FlowConfig(
+                mode="deliberation",
+                participants=["advogado"],
+                leader="advogado",
+                agent_timeouts={"advogado": 0.5},
+            )
+
+    def test_on_timeout_action_invalid_rejected(self) -> None:
+        """Invalid on_timeout_action raises error."""
+        with pytest.raises(ValidationError):
+            FlowConfig(
+                mode="deliberation",
+                participants=["advogado"],
+                leader="advogado",
+                on_timeout_action="foo",
+            )
+
+    def test_unknown_agent_id_in_timeouts_warns(self) -> None:
+        """Unknown agent IDs emit a warning (not a fatal error)."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            FlowConfig(
+                mode="deliberation",
+                participants=["advogado", "engenheiro"],
+                leader="advogado",
+                agent_timeouts={"advogado": 120.0, "unknown_agent": 60.0},
+            )
+            unknown_warnings = [
+                x.message for x in w if "unknown_agent" in str(x.message)
+            ]
+            assert len(unknown_warnings) >= 1

--- a/tests/contracts/test_timeout_resolution.py
+++ b/tests/contracts/test_timeout_resolution.py
@@ -1,0 +1,77 @@
+"""Tests for resolve_timeout precedence matrix — Spec 013."""
+
+import pytest
+
+from miniautogen.core.contracts.timeout_resolution import (
+    ResolvedTimeout,
+    resolve_timeout,
+)
+
+
+class TestResolveTimeout:
+    """Cover the full precedence matrix: agent > round > flow > engine."""
+
+    def test_agent_precedence(self) -> None:
+        """Agent-level timeout wins when set."""
+        result = resolve_timeout(
+            agent_id="engenheiro",
+            round_name="contribute",
+            agent_timeouts={"engenheiro": 60.0},
+            round_timeouts={"contribute": 90.0},
+            flow_timeout=120.0,
+            engine_timeout=300.0,
+        )
+        assert result.seconds == 60.0
+        assert result.source == "agent"
+
+    def test_round_precedence_when_agent_missing(self) -> None:
+        """Round-level timeout wins when agent timeout is absent."""
+        result = resolve_timeout(
+            agent_id="engenheiro",
+            round_name="contribute",
+            agent_timeouts={},
+            round_timeouts={"contribute": 90.0},
+            flow_timeout=120.0,
+            engine_timeout=300.0,
+        )
+        assert result.seconds == 90.0
+        assert result.source == "round"
+
+    def test_flow_precedence_when_below_missing(self) -> None:
+        """Flow-level timeout wins when agent and round are absent."""
+        result = resolve_timeout(
+            agent_id="engenheiro",
+            round_name="contribute",
+            agent_timeouts={},
+            round_timeouts={},
+            flow_timeout=120.0,
+            engine_timeout=300.0,
+        )
+        assert result.seconds == 120.0
+        assert result.source == "flow"
+
+    def test_engine_fallback(self) -> None:
+        """Engine timeout is the final fallback."""
+        result = resolve_timeout(
+            agent_id="engenheiro",
+            round_name="contribute",
+            agent_timeouts={},
+            round_timeouts={},
+            flow_timeout=None,
+            engine_timeout=300.0,
+        )
+        assert result.seconds == 300.0
+        assert result.source == "engine"
+
+    def test_agent_still_wins_when_round_also_set(self) -> None:
+        """Agent beats round when both are set (precedence)."""
+        result = resolve_timeout(
+            agent_id="engenheiro",
+            round_name="contribute",
+            agent_timeouts={"engenheiro": 60.0},
+            round_timeouts={"contribute": 90.0},
+            flow_timeout=120.0,
+            engine_timeout=300.0,
+        )
+        assert result.seconds == 60.0
+        assert result.source == "agent"

--- a/tests/core/runtime/test_deliberation_runtime.py
+++ b/tests/core/runtime/test_deliberation_runtime.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
+import anyio
 import pytest
 
-from miniautogen.core.contracts.coordination import CoordinationKind, CoordinationMode, DeliberationPlan
+from miniautogen.core.contracts.coordination import (
+    CoordinationKind,
+    CoordinationMode,
+    DeliberationPlan,
+)
 from miniautogen.core.contracts.deliberation import (
     DeliberationState,
     FinalDocument,
@@ -19,7 +24,7 @@ from miniautogen.core.contracts.run_result import RunResult
 from miniautogen.core.events.event_sink import InMemoryEventSink
 from miniautogen.core.runtime.deliberation_runtime import DeliberationRuntime
 from miniautogen.core.runtime.pipeline_runner import PipelineRunner
-
+from miniautogen.policies.timeout_policy import TimeoutPolicy
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -126,10 +131,15 @@ class FakeAgent:
 def _make_runtime(
     agents: dict[str, Any] | None = None,
     event_sink: InMemoryEventSink | None = None,
+    timeout_policy: TimeoutPolicy | None = None,
 ) -> DeliberationRuntime:
     sink = event_sink or InMemoryEventSink()
     runner = PipelineRunner(event_sink=sink)
-    return DeliberationRuntime(runner=runner, agent_registry=agents)
+    return DeliberationRuntime(
+        runner=runner,
+        agent_registry=agents,
+        timeout_policy=timeout_policy,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -171,6 +181,52 @@ async def test_minimal_deliberation_2_agents_1_round() -> None:
 
     # Leader should have consolidated
     assert len(agent_a.consolidate_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_leader_synthesis_uses_documented_synthesize_round_timeout() -> None:
+    event_sink = InMemoryEventSink()
+
+    class SlowConsolidatingAgent(FakeAgent):
+        async def consolidate(
+            self,
+            topic: str,
+            contributions: list[ResearchOutput],
+            reviews: list[PeerReview] | None = None,
+        ) -> DeliberationState:
+            await anyio.sleep(0.2)
+            return await super().consolidate(topic, contributions, reviews)
+
+    timeout_policy = TimeoutPolicy(
+        agent_timeouts={},
+        round_timeouts={"synthesize": 0.05},
+        flow_timeout=None,
+        engine_timeout=5.0,
+        on_timeout_action="continue",
+    )
+    agent_a = SlowConsolidatingAgent("leader")
+    agent_b = FakeAgent("researcher")
+    runtime = _make_runtime(
+        agents={"leader": agent_a, "researcher": agent_b},
+        event_sink=event_sink,
+        timeout_policy=timeout_policy,
+    )
+
+    plan = DeliberationPlan(
+        topic="Evaluate market entry",
+        participants=["leader", "researcher"],
+        leader_agent="leader",
+        max_rounds=1,
+    )
+
+    await runtime.run(agents=[], context=_make_context(), plan=plan)
+
+    timed_out = [
+        event for event in event_sink.events if event.type == "agent_turn_timed_out"
+    ]
+    assert len(timed_out) == 1
+    assert timed_out[0].get_payload("round_name") == "synthesize"
+    assert timed_out[0].get_payload("source") == "round"
 
 
 @pytest.mark.asyncio

--- a/tests/core/runtime/test_flow_config_propagation.py
+++ b/tests/core/runtime/test_flow_config_propagation.py
@@ -1,11 +1,16 @@
 """Tests that FlowConfig response_format and prompts propagate to AgentRuntime."""
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 
-from miniautogen.cli.config import FlowConfig
+from miniautogen.cli.config import (
+    EngineConfig,
+    FlowConfig,
+    ProjectMeta,
+    WorkspaceConfig,
+)
+from miniautogen.core.runtime.pipeline_runner import PipelineRunner, _build_timeout_policy
+from miniautogen.policies.execution import ExecutionPolicy
 
 
 class TestFlowConfigPropagation:
@@ -22,3 +27,37 @@ class TestFlowConfigPropagation:
         )
         assert fc.prompts["contribute"] == "Custom {topic} prompt."
         assert fc.response_format == "free_text"
+
+
+@pytest.mark.anyio()
+async def test_cli_timeout_wires_to_config_driven_flow_timeout_source() -> None:
+    """Config-driven flows use the runner execution timeout as flow timeout."""
+    runner = PipelineRunner(execution_policy=ExecutionPolicy(timeout_seconds=5.0))
+    config = WorkspaceConfig(
+        project=ProjectMeta(name="test"),
+        engines={"default_api": EngineConfig(timeout_seconds=120.0)},
+    )
+    flow_config = FlowConfig(
+        mode="workflow",
+        participants=["agent"],
+        agent_timeouts={},
+        round_timeouts={},
+    )
+
+    policy = _build_timeout_policy(
+        flow_config=flow_config,
+        config=config,
+        flow_timeout=runner.execution_policy.timeout_seconds,
+    )
+    events: list[dict[str, object]] = []
+
+    async def emit(event_type: str, **payload: object) -> None:
+        events.append({"type": event_type, **payload})
+
+    async with policy.scope_for_turn(
+        agent_id="agent",
+        round_name=None,
+        emit=emit,
+    ) as resolved:
+        assert resolved.seconds == 5.0
+        assert resolved.source == "flow"

--- a/tests/core/runtime/test_workflow_runtime.py
+++ b/tests/core/runtime/test_workflow_runtime.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from typing import Any
-from unittest.mock import AsyncMock
 
 import pytest
 
@@ -15,10 +14,10 @@ from miniautogen.core.contracts.coordination import (
     WorkflowStep,
 )
 from miniautogen.core.contracts.run_context import RunContext
-from miniautogen.core.contracts.run_result import RunResult
 from miniautogen.core.events.event_sink import InMemoryEventSink
 from miniautogen.core.runtime.pipeline_runner import PipelineRunner
 from miniautogen.core.runtime.workflow_runtime import WorkflowRuntime
+from miniautogen.policies.timeout_policy import TimeoutPolicy
 
 
 def _make_context(run_id: str = "run-1") -> RunContext:
@@ -47,6 +46,16 @@ class _FailingAgent:
 
     async def process(self, input_data: Any) -> Any:
         raise RuntimeError("step exploded")
+
+
+class _SlowAgent:
+    """Agent that exceeds timeout policy limits."""
+
+    async def process(self, input_data: Any) -> Any:
+        import anyio
+
+        await anyio.sleep(2.0)
+        return f"{input_data}-late"
 
 
 class _CallableAgent:
@@ -201,6 +210,45 @@ async def test_step_failure_returns_error_result() -> None:
     assert result.status == "failed"
     assert result.error is not None
     assert "RuntimeError" in result.error
+
+
+@pytest.mark.asyncio
+async def test_sequential_step_timeout_fails_workflow_with_agent_timeout() -> None:
+    """Workflow timeouts terminate the flow instead of feeding None to later steps."""
+    event_sink = InMemoryEventSink()
+    runner = PipelineRunner(event_sink=event_sink)
+    timeout_policy = TimeoutPolicy(
+        agent_timeouts={"slow": 0.1},
+        round_timeouts={},
+        flow_timeout=None,
+        engine_timeout=120.0,
+        on_timeout_action="continue",
+    )
+    runtime = WorkflowRuntime(
+        runner=runner,
+        agent_registry={"slow": _SlowAgent(), "next": _FakeAgent("next")},
+        timeout_policy=timeout_policy,
+    )
+
+    plan = WorkflowPlan(
+        steps=[
+            WorkflowStep(component_name="slow-step", agent_id="slow"),
+            WorkflowStep(component_name="next-step", agent_id="next"),
+        ],
+    )
+
+    result = await runtime.run(agents=[], context=_make_context(), plan=plan)
+
+    assert result.status == "timed_out"
+    assert result.error == "agent_timeout"
+    assert all(
+        event.type != "run_finished" or event.scope != "workflow_runtime"
+        for event in event_sink.events
+    )
+    assert any(
+        event.type == "run_timed_out" and event.scope == "workflow_runtime"
+        for event in event_sink.events
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/policies/test_timeout_policy.py
+++ b/tests/policies/test_timeout_policy.py
@@ -1,0 +1,129 @@
+"""Tests for TimeoutPolicy — Spec 013."""
+
+from __future__ import annotations
+
+import anyio
+import pytest
+
+from miniautogen.core.contracts.events import ExecutionEvent
+from miniautogen.policies.timeout_policy import TimeoutPolicy
+
+pytestmark = pytest.mark.anyio
+
+
+class TestTimeoutPolicy:
+    async def test_timeout_emits_event_and_continues(self) -> None:
+        """Timeout emits agent_turn_timed_out and suppresses exception."""
+        events: list[ExecutionEvent] = []
+
+        async def emit(event_type: str, **payload: object) -> None:
+            events.append(ExecutionEvent(type=event_type, payload=payload))
+
+        policy = TimeoutPolicy(
+            agent_timeouts={"agent_a": 0.1},
+            round_timeouts={},
+            flow_timeout=None,
+            engine_timeout=120.0,
+            on_timeout_action="continue",
+        )
+
+        async def turn_slow() -> None:
+            await anyio.sleep(2.0)
+
+        async with policy.scope_for_turn(
+            agent_id="agent_a",
+            round_name="contribute",
+            emit=emit,
+        ) as resolved:
+            with anyio.move_on_after(2.0):
+                await turn_slow()
+
+        assert len(events) >= 1
+        timed_out = [e for e in events if e.type == "agent_turn_timed_out"]
+        assert len(timed_out) == 1
+        assert timed_out[0].get_payload("agent_id") == "agent_a"
+        assert timed_out[0].get_payload("source") == "agent"
+
+    async def test_abort_action_propagates_timeout_error(self) -> None:
+        """on_timeout_action='abort' re-raises TimeoutError."""
+        events: list[ExecutionEvent] = []
+
+        async def emit(event_type: str, **payload: object) -> None:
+            events.append(ExecutionEvent(type=event_type, payload=payload))
+
+        policy = TimeoutPolicy(
+            agent_timeouts={"agent_a": 0.1},
+            round_timeouts={},
+            flow_timeout=None,
+            engine_timeout=120.0,
+            on_timeout_action="abort",
+        )
+
+        with pytest.raises(TimeoutError):
+            async with policy.scope_for_turn(
+                agent_id="agent_a",
+                round_name="contribute",
+                emit=emit,
+            ):
+                await anyio.sleep(2.0)
+
+        assert len(events) >= 1
+        timed_out = [e for e in events if e.type == "agent_turn_timed_out"]
+        assert len(timed_out) == 1
+
+    async def test_outer_fail_after_cancels_before_agent_timeout(self) -> None:
+        """Outer flow-level fail_after cancels before the policy's agent
+        timeout fires — simulates runner-level nesting (flow < agent)."""
+        events: list[str] = []
+
+        async def emit(event_type: str, **payload: object) -> None:
+            events.append(event_type)
+
+        policy = TimeoutPolicy(
+            agent_timeouts={"agent_a": 10.0},
+            round_timeouts={},
+            flow_timeout=10.0,
+            engine_timeout=120.0,
+            on_timeout_action="continue",
+        )
+
+        with pytest.raises(TimeoutError):
+            with anyio.fail_after(0.05):
+                async with policy.scope_for_turn(
+                    agent_id="agent_a",
+                    round_name="contribute",
+                    emit=emit,
+                ):
+                    await anyio.sleep(5.0)
+
+        assert "agent_turn_timed_out" not in events
+
+    async def test_emits_payload_with_source_agent(self) -> None:
+        """Event payload includes source='agent' when agent timeout fires."""
+        events: list[ExecutionEvent] = []
+
+        async def emit(event_type: str, **payload: object) -> None:
+            events.append(ExecutionEvent(type=event_type, payload=payload))
+
+        policy = TimeoutPolicy(
+            agent_timeouts={"agent_a": 0.1},
+            round_timeouts={},
+            flow_timeout=None,
+            engine_timeout=120.0,
+            on_timeout_action="continue",
+        )
+
+        async with policy.scope_for_turn(
+            agent_id="agent_a",
+            round_name="contribute",
+            emit=emit,
+        ):
+            await anyio.sleep(1.0)
+
+        timed_out = [e for e in events if e.type == "agent_turn_timed_out"]
+        assert len(timed_out) == 1
+        payload = timed_out[0]
+        assert payload.get_payload("source") == "agent"
+        assert payload.get_payload("agent_id") == "agent_a"
+        assert payload.get_payload("round_name") == "contribute"
+        assert payload.get_payload("applied_timeout") == 0.1


### PR DESCRIPTION
### Descrição
Implementação da Spec 013, introduzindo suporte a **Timeouts (SLAs)** em múltiplos níveis de granularidade.

O gerenciamento de tempo limite agora se baseia na seguinte matriz de precedência:
1. **Por agente** (`agent_timeouts`): maior prioridade.
2. **Por round/fase** (`round_timeouts`): ex. `contribute`, `review`, `synthesize`.
3. **Por fluxo** (`flow_timeout` ou `--timeout` no CLI).
4. **Por engine** (`timeout_seconds` da API): fallback com menor prioridade.

### Detalhes das Alterações
- Inserido suporte aos modos `continue` (ignorar o agente silenciosamente) e `abort` (falhar o fluxo).
- **`FlowConfig`:** Validadores incluídos (via Pydantic) para garantir coerência nos `agent_timeouts` e `round_timeouts`.
- **Core / Runtimes:** O wrapper `TimeoutPolicy` (usando o `anyio.fail_after`) foi injetado nos `DeliberationRuntime`, `AgenticLoopRuntime` e `WorkflowRuntime`.
- Evento `AGENT_TURN_TIMED_OUT` criado para observabilidade.
- Testes unitários completos, cobrindo precedência, comportamentos do CLI e fluxos com falha (abort e continue).

---
*Nota de revisão (WorkflowRuntime)*: Foi observado no review que o `WorkflowRuntime` abortará no caso de timeout (`WorkflowAgentTimeout`) até mesmo se o modo estivesse como `continue`. Esse é o comportamento desenhado para pipelines estritamente sequenciais no qual uma etapa nula corromperia as etapas subsequentes.