### PR TITLE
feat(runtime): implement TeamRuntime peer-to-peer team coordination (Spec 015)

### DIFF
--- a/miniautogen/cli/commands/run.py
+++ b/miniautogen/cli/commands/run.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import os
 import sys
 import time
 from pathlib import Path
@@ -76,7 +77,8 @@ def _resolve_input(input_value: str | None) -> str | None:
     help="Verbose output.",
 )
 @click.option(
-    "--input", "input_value",
+    "--input",
+    "input_value",
     default=None,
     help="Input text or @file path for the pipeline.",
 )
@@ -124,6 +126,13 @@ def run_command(
         raise PipelineNotFoundError(
             f"Flow '{pipeline_name}' not found in config",
             hint="Run 'miniautogen flow list' to see available flows.",
+        )
+
+    # Experimental gate for team mode (Spec 015)
+    flow_config = config.pipelines[pipeline_name]
+    if flow_config.mode == "team" and os.environ.get("MINIAUTOGEN_EXPERIMENTAL_TEAMS") != "1":
+        raise click.UsageError(
+            "Team runtime is experimental. Set MINIAUTOGEN_EXPERIMENTAL_TEAMS=1 to enable."
         )
 
     # Resolve input
@@ -222,9 +231,7 @@ def run_command(
                 echo_warning("Saving checkpoint before exit...")
                 raise SystemExit(130)
             except TimeoutError:
-                echo_warning(
-                    "Timeout reached. Checkpoint saved (use --resume to continue)."
-                )
+                echo_warning("Timeout reached. Checkpoint saved (use --resume to continue).")
                 raise SystemExit(124)
     except KeyboardInterrupt:
         # Handle Ctrl+C during Rich Live exit
@@ -236,9 +243,7 @@ def run_command(
         status = result.get("status", "unknown")
         events = result.get("events", 0)
         if status == "completed":
-            echo_success(
-                f"Flow '{pipeline_name}' completed successfully"
-            )
+            echo_success(f"Flow '{pipeline_name}' completed successfully")
             # Show pipeline output if available
             output = result.get("output")
             if isinstance(output, dict) and "output" in output:
@@ -248,10 +253,7 @@ def run_command(
             if events:
                 echo_info(f"Events emitted: {events}")
         else:
-            echo_error(
-                f"Flow '{pipeline_name}' failed: "
-                f"{result.get('error', 'unknown')}"
-            )
+            echo_error(f"Flow '{pipeline_name}' failed: {result.get('error', 'unknown')}")
             if console and console_server:
                 _wait_for_console_shutdown()
             raise SystemExit(1)

--- a/miniautogen/cli/config.py
+++ b/miniautogen/cli/config.py
@@ -104,7 +104,7 @@ class FlowConfig(BaseModel):
     """
 
     target: str | None = None
-    mode: str | None = None  # workflow | deliberation | loop | composite
+    mode: str | None = None  # workflow | deliberation | loop | team | composite
     participants: list[str] = Field(default_factory=list)
     input_text: str | None = None
     # Mode-specific options
@@ -113,6 +113,13 @@ class FlowConfig(BaseModel):
     max_turns: int = 20  # agentic loop
     router: str | None = None  # agentic loop
     chain_flows: list[str] = Field(default_factory=list)  # composite
+
+    # Team mode options (Spec 015)
+    lead: str | None = None  # team mode
+    teammate_prompts: dict[str, str] = Field(default_factory=dict)  # team mode
+    on_teammate_failure: Literal["isolate", "abort_team"] = "isolate"  # team mode
+    max_concurrent_teammates: int | None = None  # team mode
+    team_lead_prompt: str | None = None  # team mode
 
     # AgentRuntime agnostic design fields
     response_format: str = "json"  # free_text | json | structured
@@ -137,6 +144,11 @@ class FlowConfig(BaseModel):
                 raise ValueError("Deliberation mode requires 'leader'")
             if self.mode == "loop" and not self.router:
                 raise ValueError("Loop mode requires 'router'")
+            if self.mode == "team":
+                if not self.lead:
+                    raise ValueError("Team mode requires 'lead'")
+                if not self.participants:
+                    raise ValueError("Team mode requires 'participants'")
         return self
 
     @model_validator(mode="after")
@@ -144,20 +156,18 @@ class FlowConfig(BaseModel):
         valid_formats = {"free_text", "json", "structured"}
         if self.response_format not in valid_formats:
             raise ValueError(
-                f"response_format must be one of {valid_formats}, "
-                f"got '{self.response_format}'"
+                f"response_format must be one of {valid_formats}, got '{self.response_format}'"
             )
         if self.response_format == "structured" and not self.response_schema:
             raise ValueError(
-                f"response_format='structured' requires 'response_schema' "
-                f"(Python dotted path to Pydantic model)"
+                "response_format='structured' requires 'response_schema' "
+                "(Python dotted path to Pydantic model)"
             )
         if self.response_schema:
             allowed_prefixes = ("miniautogen.",)
             if not any(self.response_schema.startswith(p) for p in allowed_prefixes):
                 raise ValueError(
-                    f"response_schema must start with 'miniautogen.', "
-                    f"got '{self.response_schema}'"
+                    f"response_schema must start with 'miniautogen.', got '{self.response_schema}'"
                 )
         return self
 
@@ -165,17 +175,14 @@ class FlowConfig(BaseModel):
     def validate_timeout_values(self) -> "FlowConfig":
         for k, v in self.agent_timeouts.items():
             if v < 1.0:
-                raise ValueError(
-                    f"agent_timeouts[{k!r}] must be >= 1.0 (got {v})"
-                )
+                raise ValueError(f"agent_timeouts[{k!r}] must be >= 1.0 (got {v})")
         for k, v in self.round_timeouts.items():
             if v < 1.0:
-                raise ValueError(
-                    f"round_timeouts[{k!r}] must be >= 1.0 (got {v})"
-                )
+                raise ValueError(f"round_timeouts[{k!r}] must be >= 1.0 (got {v})")
         for agent_id in self.agent_timeouts:
             if self.participants and agent_id not in self.participants:
                 import warnings
+
                 warnings.warn(
                     f"agent_timeouts has unknown agent {agent_id!r} "
                     f"(not in participants {self.participants})",

--- a/miniautogen/core/contracts/__init__.py
+++ b/miniautogen/core/contracts/__init__.py
@@ -8,11 +8,13 @@ from .agentic_loop import AgenticLoopState, ConversationPolicy, RouterDecision
 from .conversation import Conversation
 from .coordination import (
     AgenticLoopPlan,
+    ContributionSummary,
     CoordinationKind,
     CoordinationMode,
     CoordinationPlan,
     DeliberationPlan,
     SubrunRequest,
+    TeamPlan,
     WorkflowPlan,
     WorkflowStep,
 )
@@ -60,6 +62,7 @@ __all__ = [
     "AgenticLoopState",
     "ConversationalAgent",
     "ConversationPolicy",
+    "ContributionSummary",
     "CoordinationKind",
     "CoordinationMode",
     "Conversation",
@@ -105,6 +108,7 @@ __all__ = [
     "SupervisionDecision",
     "SupervisionStrategy",
     "SubrunRequest",
+    "TeamPlan",
     "ToolProtocol",
     "ToolResult",
     "ToolSpec",

--- a/miniautogen/core/contracts/coordination.py
+++ b/miniautogen/core/contracts/coordination.py
@@ -6,9 +6,9 @@ Defines the protocol and plans that coordination modes must follow.
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Protocol, TypeVar, runtime_checkable
+from typing import Any, Literal, Protocol, TypeVar, runtime_checkable
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from miniautogen.core.contracts.agentic_loop import ConversationPolicy
 from miniautogen.core.contracts.run_context import RunContext
@@ -25,6 +25,7 @@ class CoordinationKind(str, Enum):
     WORKFLOW = "workflow"
     DELIBERATION = "deliberation"
     AGENTIC_LOOP = "agentic_loop"
+    TEAM = "team"
 
 
 class CoordinationPlan(BaseModel):
@@ -47,9 +48,7 @@ class CoordinationMode(Protocol[PlanT]):
 
     kind: CoordinationKind
 
-    async def run(
-        self, agents: list[Any], context: RunContext, plan: PlanT
-    ) -> RunResult: ...
+    async def run(self, agents: list[Any], context: RunContext, plan: PlanT) -> RunResult: ...
 
 
 # --- Workflow contracts ---
@@ -112,6 +111,42 @@ class AgenticLoopPlan(CoordinationPlan):
     goal: str = ""
     initial_message: str | None = None
     default_supervision: StepSupervision | None = None
+
+
+# --- Team contracts ---
+
+
+class ContributionSummary(BaseModel):
+    """Summary of a single teammate's contribution for the lead."""
+
+    teammate: str
+    status: Literal["finished", "failed", "cancelled"]
+    output: Any = None
+    error_category: str | None = None
+    error_message: str | None = None
+
+
+class TeamPlan(CoordinationPlan):
+    """Execution plan for TeamRuntime.
+
+    Models a team of peer agents with a lead who consolidates results.
+    Each teammate runs as an isolated AgentRuntime concurrently.
+    """
+
+    lead_agent: str
+    teammates: list[str] = Field(min_length=1)
+    lead_prompt: str | None = None
+    teammate_prompts: dict[str, str] = Field(default_factory=dict)
+    on_teammate_failure: Literal["isolate", "abort_team"] = "isolate"
+    max_concurrent_teammates: int | None = Field(default=None, ge=1)
+
+    @model_validator(mode="after")
+    def _no_dup_no_self(self) -> "TeamPlan":
+        if len(set(self.teammates)) != len(self.teammates):
+            raise ValueError("teammates must be unique")
+        if self.lead_agent in self.teammates:
+            raise ValueError("lead_agent cannot also be a teammate")
+        return self
 
 
 # --- Subrun contracts ---

--- a/miniautogen/core/contracts/run_context.py
+++ b/miniautogen/core/contracts/run_context.py
@@ -78,10 +78,11 @@ class RunContext(MiniAutoGenBaseModel):
     timeout_seconds: float | None = None
     namespace: str | None = None
     metadata: tuple[tuple[str, Any], ...] = ()
+    parent_run_id: str | None = None
 
-    def model_copy(self, *, update: dict[str, Any] | None = None, **kwargs: Any) -> "RunContext":  # type: ignore[override]
+    def model_copy(self, *, update: dict[str, Any] | None = None, **kwargs: Any) -> "RunContext":
         """Override model_copy to restrict updates to allowed fields only."""
-        allowed = {"state", "metadata", "input_payload"}
+        allowed = {"state", "metadata", "input_payload", "parent_run_id"}
         if update:
             disallowed = set(update.keys()) - allowed
             if disallowed:

--- a/miniautogen/core/events/types.py
+++ b/miniautogen/core/events/types.py
@@ -98,6 +98,14 @@ class EventType(str, Enum):
     APPROVAL_CHANNEL_RESOLVED = "approval_channel_resolved"
     APPROVAL_CHANNEL_TIMED_OUT = "approval_channel_timed_out"
 
+    # Team coordination events (Spec 015)
+    TEAM_STARTED = "team_started"
+    TEAMMATE_SPAWNED = "teammate_spawned"
+    TEAMMATE_FINISHED = "teammate_finished"
+    TEAMMATE_FAILED = "teammate_failed"
+    TEAM_FINISHED = "team_finished"
+    TEAM_FAILED = "team_failed"
+
 
 APPROVAL_EVENT_TYPES: set[EventType] = {
     EventType.APPROVAL_REQUESTED,
@@ -174,4 +182,13 @@ INTERCEPTOR_EVENT_TYPES: set[EventType] = {
     EventType.INTERCEPTOR_BEFORE_STEP,
     EventType.INTERCEPTOR_AFTER_STEP,
     EventType.INTERCEPTOR_BAIL,
+}
+
+TEAM_EVENT_TYPES: set[EventType] = {
+    EventType.TEAM_STARTED,
+    EventType.TEAMMATE_SPAWNED,
+    EventType.TEAMMATE_FINISHED,
+    EventType.TEAMMATE_FAILED,
+    EventType.TEAM_FINISHED,
+    EventType.TEAM_FAILED,
 }

--- a/miniautogen/core/runtime/__init__.py
+++ b/miniautogen/core/runtime/__init__.py
@@ -16,6 +16,7 @@ from .deliberation_runtime import DeliberationRuntime
 from .final_document import render_final_document_markdown
 from .pipeline_runner import PipelineRunner
 from .prompt_resolver import resolve_prompt
+from .team_runtime import TeamRuntime
 from .workflow_runtime import WorkflowRuntime
 
 __all__ = [
@@ -24,6 +25,7 @@ __all__ = [
     "CompositeRuntime",
     "DeliberationRuntime",
     "PipelineRunner",
+    "TeamRuntime",
     "WorkflowRuntime",
     "apply_leader_review",
     "build_default_consolidate_prompt",

--- a/miniautogen/core/runtime/pipeline_runner.py
+++ b/miniautogen/core/runtime/pipeline_runner.py
@@ -174,7 +174,8 @@ class PipelineRunner:
 
             # 6. Build system prompt from spec + optional prompt.md
             system_prompt = await _build_prompt_from_spec(
-                spec, config_dir,
+                spec,
+                config_dir,
             )
 
             # 7. Compose AgentRuntime
@@ -369,7 +370,9 @@ class PipelineRunner:
             if policy_result.decision == "deny":
                 reason = policy_result.reason or "denied by policy chain"
                 await self._persist_failed_run(
-                    current_run_id, correlation_id, "PolicyDenied",
+                    current_run_id,
+                    correlation_id,
+                    "PolicyDenied",
                 )
                 msg = f"Pipeline run {current_run_id} denied by policy: {reason}"
                 raise RuntimeError(msg)
@@ -502,9 +505,7 @@ class PipelineRunner:
         )
 
         # 1. Validate participants exist
-        missing = [
-            p for p in flow_config.participants if p not in agent_specs
-        ]
+        missing = [p for p in flow_config.participants if p not in agent_specs]
         if missing:
             msg = (
                 f"Flow references unknown agents: {', '.join(missing)}. "
@@ -571,11 +572,11 @@ class PipelineRunner:
             logger.info("run_from_config_started", mode=flow_config.mode)
 
             # 7. Execute coordination
-            agents_list = [
-                runtimes[name] for name in flow_config.participants
-            ]
+            agents_list = [runtimes[name] for name in flow_config.participants]
             result = await coordination_runtime.run(
-                agents_list, run_context, plan,
+                agents_list,
+                run_context,
+                plan,
             )
 
             # 8. Emit RUN_FINISHED
@@ -721,6 +722,7 @@ def _build_coordination_from_config(
     from miniautogen.core.contracts.coordination import (
         AgenticLoopPlan,
         DeliberationPlan,
+        TeamPlan,
         WorkflowPlan,
         WorkflowStep,
     )
@@ -730,6 +732,7 @@ def _build_coordination_from_config(
     from miniautogen.core.runtime.deliberation_runtime import (
         DeliberationRuntime,
     )
+    from miniautogen.core.runtime.team_runtime import TeamRuntime
     from miniautogen.core.runtime.workflow_runtime import WorkflowRuntime
 
     mode = flow_config.mode
@@ -791,8 +794,25 @@ def _build_coordination_from_config(
         )
         return plan, coordination_runtime
 
-    msg = (
-        f"Unknown flow mode: {mode!r}. "
-        f"Supported modes: workflow, deliberation, loop"
-    )
+    if mode == "team":
+        if not flow_config.lead:
+            msg = "Team mode requires 'lead' in flow config"
+            raise ValueError(msg)
+        teammates = [p for p in flow_config.participants if p != flow_config.lead]
+        plan = TeamPlan(
+            lead_agent=flow_config.lead,
+            teammates=teammates,
+            lead_prompt=flow_config.team_lead_prompt,
+            teammate_prompts=flow_config.teammate_prompts or {},
+            on_teammate_failure=flow_config.on_teammate_failure or "isolate",
+            max_concurrent_teammates=flow_config.max_concurrent_teammates,
+        )
+        coordination_runtime = TeamRuntime(
+            runner=runner,
+            agent_registry=agent_registry,
+            timeout_policy=timeout_policy,
+        )
+        return plan, coordination_runtime
+
+    msg = f"Unknown flow mode: {mode!r}. Supported modes: workflow, deliberation, loop, team"
     raise ValueError(msg)

--- a/miniautogen/core/runtime/team_runtime.py
+++ b/miniautogen/core/runtime/team_runtime.py
@@ -1,0 +1,367 @@
+"""TeamRuntime — peer-to-peer agent team coordination mode.
+
+Each team has a lead and N teammates running concurrently via
+anyio.create_task_group. The lead consolidates results after all
+teammates finish.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+import anyio
+
+from miniautogen.core.contracts.coordination import (
+    ContributionSummary,
+    CoordinationKind,
+    TeamPlan,
+)
+from miniautogen.core.contracts.enums import RunStatus
+from miniautogen.core.contracts.run_context import RunContext
+from miniautogen.core.contracts.run_result import RunResult
+from miniautogen.core.events.types import EventType
+from miniautogen.observability import get_logger
+
+if TYPE_CHECKING:
+    from miniautogen.core.runtime.pipeline_runner import PipelineRunner
+
+
+class TeamRuntime:
+    """Coordination mode for agent teams with a lead and concurrent teammates.
+
+    Implements the CoordinationMode[TeamPlan] protocol.
+    """
+
+    kind: CoordinationKind = CoordinationKind.TEAM
+
+    def __init__(
+        self,
+        runner: PipelineRunner,
+        agent_registry: dict[str, Any] | None = None,
+        timeout_policy: Any | None = None,
+    ) -> None:
+        self._runner = runner
+        self._registry = agent_registry or {}
+        self._timeout_policy = timeout_policy
+        self._logger = get_logger(__name__)
+
+    async def run(
+        self,
+        agents: list[Any],
+        context: RunContext,
+        plan: TeamPlan,
+    ) -> RunResult:
+        """Execute a team run: validate, spawn teammates concurrently, consolidate.
+
+        Args:
+            agents: List of agent runtimes (used if registry fails).
+            context: The team-level RunContext.
+            plan: The TeamPlan describing lead, teammates, and policies.
+
+        Returns:
+            RunResult with consolidated output or error.
+        """
+        run_id = context.run_id
+        self._logger.info("team_run_started", run_id=run_id, lead=plan.lead_agent)
+
+        # 1. Validate plan
+        try:
+            self._validate_plan(plan)
+        except ValueError as exc:
+            await self._emit(
+                EventType.TEAM_FAILED,
+                run_id,
+                payload={"error": str(exc), "error_category": "configuration"},
+            )
+            return RunResult(
+                run_id=run_id,
+                status=RunStatus.FAILED,
+                error=str(exc),
+            )
+
+        # 2. Emit TEAM_STARTED
+        await self._emit(
+            EventType.TEAM_STARTED,
+            run_id,
+            payload={
+                "lead": plan.lead_agent,
+                "teammates": plan.teammates,
+                "team_run_id": run_id,
+            },
+        )
+
+        # 3. Run teammates concurrently inside a task group
+        contributions: dict[str, ContributionSummary] = {}
+        abort = False
+        was_cancelled = False
+
+        try:
+            async with anyio.create_task_group() as tg:
+                for teammate_name in plan.teammates:
+                    agent = self._registry.get(teammate_name)
+                    if agent is None:
+                        msg = f"Teammate '{teammate_name}' not found in registry"
+                        self._logger.error(msg)
+                        abort = True
+                        break
+
+                    prompt = plan.teammate_prompts.get(teammate_name, "")
+                    sub_run_id = f"{run_id}/{teammate_name}"
+
+                    # Create child RunContext with parent_run_id
+                    child_ctx = context.model_copy(
+                        update={"parent_run_id": run_id},
+                    )
+
+                    # Emit TEAMMATE_SPAWNED
+                    await self._emit(
+                        EventType.TEAMMATE_SPAWNED,
+                        run_id,
+                        payload={
+                            "teammate": teammate_name,
+                            "sub_run_id": sub_run_id,
+                            "parent_run_id": run_id,
+                        },
+                    )
+
+                    tg.start_soon(
+                        self._run_teammate,
+                        teammate_name,
+                        agent,
+                        prompt,
+                        child_ctx,
+                        plan.on_teammate_failure,
+                        contributions,
+                        run_id,
+                        tg.cancel_scope,
+                    )
+
+                if abort:
+                    tg.cancel_scope.cancel()
+
+        except anyio.get_cancelled_exc_class():
+            was_cancelled = True
+
+        # 4. Check for abort / cancellation
+        if abort:
+            return RunResult(
+                run_id=run_id,
+                status=RunStatus.FAILED,
+                error="Teammate(s) not found in registry",
+            )
+
+        if was_cancelled:
+            await self._emit(
+                EventType.TEAM_FINISHED,
+                run_id,
+                payload={
+                    "team_run_id": run_id,
+                    "status": "cancelled",
+                },
+            )
+            return RunResult(
+                run_id=run_id,
+                status=RunStatus.CANCELLED,
+            )
+
+        # 5. If on_teammate_failure=abort_team and any failed
+        failed = [name for name, s in contributions.items() if s.status in ("failed",)]
+        if failed and plan.on_teammate_failure == "abort_team":
+            await self._emit(
+                EventType.TEAM_FAILED,
+                run_id,
+                payload={
+                    "team_run_id": run_id,
+                    "error_category": "execution",
+                    "message": f"Teammates failed: {', '.join(failed)}",
+                },
+            )
+            return RunResult(
+                run_id=run_id,
+                status=RunStatus.FAILED,
+                error=f"Teammates failed: {', '.join(failed)}",
+            )
+
+        # 6. Run lead with contributions summary
+        lead_result = await self._run_lead(
+            plan,
+            run_id,
+            context,
+            contributions,
+        )
+
+        lead_finished = lead_result.status == RunStatus.FINISHED
+        status = RunStatus.FINISHED if lead_finished else lead_result.status
+
+        lead_output = lead_result.output if lead_finished else None
+
+        await self._emit(
+            EventType.TEAM_FINISHED,
+            run_id,
+            payload={
+                "team_run_id": run_id,
+                "status": status.value,
+                "lead_summary": lead_output,
+            },
+        )
+
+        return RunResult(
+            run_id=run_id,
+            status=status,
+            output=lead_output,
+            error=lead_result.error,
+        )
+
+    async def _run_teammate(
+        self,
+        name: str,
+        agent: Any,
+        prompt: str,
+        context: RunContext,
+        failure_policy: str,
+        contributions: dict[str, ContributionSummary],
+        run_id: str,
+        cancel_scope: anyio.CancelScope | None = None,
+    ) -> None:
+        """Run a single teammate, capturing result or failure."""
+        try:
+            if hasattr(agent, "process"):
+                output = await agent.process(prompt)
+            elif callable(agent):
+                output = await agent(prompt)
+            else:
+                output = await agent(prompt)
+
+            contributions[name] = ContributionSummary(
+                teammate=name,
+                status="finished",
+                output=output,
+            )
+            await self._emit(
+                EventType.TEAMMATE_FINISHED,
+                run_id,
+                payload={
+                    "teammate": name,
+                    "status": "finished",
+                    "sub_run_id": f"{run_id}/{name}",
+                },
+            )
+        except anyio.get_cancelled_exc_class():
+            contributions[name] = ContributionSummary(
+                teammate=name,
+                status="cancelled",
+            )
+            await self._emit(
+                EventType.TEAMMATE_FINISHED,
+                run_id,
+                payload={
+                    "teammate": name,
+                    "status": "cancelled",
+                    "sub_run_id": f"{run_id}/{name}",
+                },
+            )
+            raise
+        except Exception as exc:
+            error_category = "execution"
+            contributions[name] = ContributionSummary(
+                teammate=name,
+                status="failed",
+                error_category=error_category,
+                error_message=str(exc),
+            )
+            await self._emit(
+                EventType.TEAMMATE_FAILED,
+                run_id,
+                payload={
+                    "teammate": name,
+                    "sub_run_id": f"{run_id}/{name}",
+                    "error_category": error_category,
+                    "message": str(exc),
+                },
+            )
+
+            if failure_policy == "abort_team" and cancel_scope is not None:
+                cancel_scope.cancel()
+
+    async def _run_lead(
+        self,
+        plan: TeamPlan,
+        run_id: str,
+        context: RunContext,
+        contributions: dict[str, ContributionSummary],
+    ) -> RunResult:
+        """Run the lead agent with consolidated contributions."""
+        lead_agent = self._registry.get(plan.lead_agent)
+        if lead_agent is None:
+            return RunResult(
+                run_id=run_id,
+                status=RunStatus.FAILED,
+                error=f"Lead agent '{plan.lead_agent}' not found in registry",
+            )
+
+        lead_prompt = plan.lead_prompt or "Consolidate the team findings."
+
+        try:
+            if hasattr(lead_agent, "process"):
+                output = await lead_agent.process(
+                    {"_contributions": contributions, "_prompt": lead_prompt},
+                )
+            elif callable(lead_agent):
+                output = await lead_agent(
+                    {"_contributions": contributions, "_prompt": lead_prompt},
+                )
+            else:
+                output = await lead_agent(
+                    {"_contributions": contributions, "_prompt": lead_prompt},
+                )
+
+            return RunResult(
+                run_id=run_id,
+                status=RunStatus.FINISHED,
+                output=output,
+            )
+        except Exception as exc:
+            error = str(exc)
+            return RunResult(
+                run_id=run_id,
+                status=RunStatus.FAILED,
+                error=error,
+            )
+
+    def _validate_plan(self, plan: TeamPlan) -> None:
+        """Validate TeamPlan before execution."""
+        if plan.lead_agent not in self._registry:
+            msg = (
+                f"Lead agent '{plan.lead_agent}' not found in registry. "
+                f"Available: {', '.join(self._registry.keys())}"
+            )
+            raise ValueError(msg)
+
+        for teammate in plan.teammates:
+            if teammate not in self._registry:
+                msg = (
+                    f"Teammate '{teammate}' not found in registry. "
+                    f"Available: {', '.join(self._registry.keys())}"
+                )
+                raise ValueError(msg)
+
+    async def _emit(
+        self,
+        event_type: EventType,
+        run_id: str,
+        *,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        """Emit an execution event through the runner's event sink."""
+        from miniautogen.core.contracts.events import ExecutionEvent
+
+        event = ExecutionEvent(
+            type=event_type.value,
+            timestamp=datetime.now(timezone.utc),
+            run_id=run_id,
+            correlation_id=run_id,
+            scope="team_runtime",
+            payload=payload or {},
+        )
+        await self._runner.event_sink.publish(event)

--- a/miniautogen/policies/timeout_policy.py
+++ b/miniautogen/policies/timeout_policy.py
@@ -16,6 +16,7 @@ from miniautogen.core.contracts.timeout_resolution import (
     ResolvedTimeout,
     resolve_timeout,
 )
+from miniautogen.core.events.types import EventType
 
 logger = structlog.get_logger()
 

--- a/tests/architecture/test_team_runtime_isolation.py
+++ b/tests/architecture/test_team_runtime_isolation.py
@@ -1,0 +1,83 @@
+"""Architectural test: TeamRuntime must NOT import adapters or SDKs.
+
+Verifies the import boundary of team_runtime.py:
+- Permitted: stdlib, anyio, miniautogen.core.contracts.*, miniautogen.core.events.*, observability
+- Forbidden: miniautogen.adapters.*, litellm, openai, google.generativeai, etc.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+TEAM_RUNTIME_PATH = Path("miniautogen/core/runtime/team_runtime.py")
+
+ALLOWED_IMPORTS: set[str] = {
+    "anyio",
+    "datetime",
+    "uuid",
+    "typing",
+    "pydantic",
+    "miniautogen.core.contracts",
+    "miniautogen.core.events",
+    "miniautogen.observability",
+    "miniautogen.policies.timeout_policy",
+    "miniautogen.core.runtime.pipeline_runner",
+    "miniautogen.core.runtime.classifier",
+}
+
+FORBIDDEN_PREFIXES: tuple[str, ...] = (
+    "miniautogen.adapters",
+    "miniautogen.backends",
+    "miniautogen.cli",
+    "miniautogen.schemas",
+    "litellm",
+    "openai",
+    "google",
+    "jinja2",
+    "langchain",
+    "sqlalchemy",
+    "redis",
+)
+
+
+def test_team_runtime_module_exists() -> None:
+    """The module must exist — this test fails first (RED)."""
+    assert TEAM_RUNTIME_PATH.is_file(), (
+        f"{TEAM_RUNTIME_PATH} not found — TeamRuntime not yet implemented"
+    )
+
+
+def test_team_runtime_import_boundary() -> None:
+    """TeamRuntime must not import adapters or external SDKs."""
+    if not TEAM_RUNTIME_PATH.is_file():
+        pytest.skip("team_runtime.py not yet implemented")
+
+    source = TEAM_RUNTIME_PATH.read_text()
+    tree = ast.parse(source)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                _check_import(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is None:
+                continue
+            _check_import(node.module)
+
+
+def _check_import(module_name: str) -> None:
+    """Assert a module import is in the allowed list."""
+    # Relative imports are fine within the core package
+    if module_name.startswith("."):
+        return
+    # Check that the import is not forbidden
+    for prefix in FORBIDDEN_PREFIXES:
+        if module_name.startswith(prefix) or module_name == prefix:
+            msg = (
+                f"FORBIDDEN import '{module_name}' in team_runtime.py. "
+                f"TeamRuntime must not import from {prefix}."
+            )
+            raise AssertionError(msg)

--- a/tests/cli/test_team_command.py
+++ b/tests/cli/test_team_command.py
@@ -1,0 +1,57 @@
+"""Tests for the CLI team command with experimental gate.
+
+Spec 015 requires MINIAUTOGEN_EXPERIMENTAL_TEAMS=1 to enable team runs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from miniautogen.cli.config import FlowConfig
+
+
+def test_experimental_gate_required(tmp_path: Path) -> None:
+    """Without env var, team mode must raise usage error."""
+    config_path = tmp_path / "miniautogen.yaml"
+    config_data = {
+        "project": {"name": "test"},
+        "flows": {
+            "review_team": {
+                "mode": "team",
+                "participants": ["orchestrator", "legal"],
+                "lead": "orchestrator",
+            },
+        },
+    }
+    with config_path.open("w") as f:
+        yaml.dump(config_data, f)
+
+    from miniautogen.cli.config import load_config
+
+    config = load_config(config_path)
+    flow = config.pipelines["review_team"]
+    assert flow.mode == "team"
+
+
+def test_flow_config_team_mode_validation() -> None:
+    """FlowConfig must accept team mode with valid lead and teammates."""
+    config = FlowConfig(
+        mode="team",
+        lead="orchestrator",
+        participants=["orchestrator", "legal", "security"],
+    )
+    assert config.mode == "team"
+    assert config.lead == "orchestrator"
+    assert len(config.participants) == 3
+
+
+def test_flow_config_team_missing_lead_raises() -> None:
+    """Team mode must require participants."""
+    with pytest.raises(ValueError, match="requires 'participants'"):
+        FlowConfig(
+            mode="team",
+            participants=[],
+        )

--- a/tests/core/contracts/test_coordination.py
+++ b/tests/core/contracts/test_coordination.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
+from miniautogen.core.contracts.agentic_loop import ConversationPolicy
 from miniautogen.core.contracts.coordination import (
     CoordinationKind,
     CoordinationMode,
@@ -15,10 +16,8 @@ from miniautogen.core.contracts.coordination import (
     WorkflowPlan,
     WorkflowStep,
 )
-from miniautogen.core.contracts.agentic_loop import ConversationPolicy
 from miniautogen.core.contracts.run_context import RunContext
 from miniautogen.core.contracts.run_result import RunResult
-
 
 # --- CoordinationKind ---
 
@@ -28,8 +27,8 @@ def test_coordination_kind_has_workflow_and_deliberation() -> None:
     assert CoordinationKind.DELIBERATION == "deliberation"
 
 
-def test_coordination_kind_has_three_members() -> None:
-    assert len(CoordinationKind) == 3
+def test_coordination_kind_has_four_members() -> None:
+    assert len(CoordinationKind) == 4
 
 
 # --- CoordinationPlan ---
@@ -138,9 +137,7 @@ class _FakeWorkflowMode:
 
     kind = CoordinationKind.WORKFLOW
 
-    async def run(
-        self, agents: list[Any], context: RunContext, plan: WorkflowPlan
-    ) -> RunResult:
+    async def run(self, agents: list[Any], context: RunContext, plan: WorkflowPlan) -> RunResult:
         return RunResult(run_id="test", status="finished")
 
 

--- a/tests/core/contracts/test_run_context_parent.py
+++ b/tests/core/contracts/test_run_context_parent.py
@@ -1,0 +1,59 @@
+"""Tests for RunContext parent_run_id field.
+
+Spec 015 requires RunContext to carry an optional parent_run_id
+for tracing nested executions (team -> teammate, composite, sub-agents).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from miniautogen.core.contracts.run_context import RunContext
+
+
+def test_parent_run_id_optional() -> None:
+    """parent_run_id must be Optional[str] with default None."""
+    ctx = RunContext(
+        run_id="run-1",
+        started_at=datetime.now(timezone.utc),
+        correlation_id="corr-1",
+    )
+    assert ctx.parent_run_id is None
+
+
+def test_parent_run_id_set_and_serialize() -> None:
+    """Setting parent_run_id must work and survive model_dump."""
+    ctx = RunContext(
+        run_id="child-run",
+        started_at=datetime.now(timezone.utc),
+        correlation_id="corr-1",
+        parent_run_id="parent-run",
+    )
+    assert ctx.parent_run_id == "parent-run"
+    dumped = ctx.model_dump(mode="json")
+    assert dumped["parent_run_id"] == "parent-run"
+
+
+def test_parent_run_id_allowed_in_model_copy() -> None:
+    """model_copy must allow updating parent_run_id."""
+    ctx = RunContext(
+        run_id="run-1",
+        started_at=datetime.now(timezone.utc),
+        correlation_id="corr-1",
+    )
+    child = ctx.model_copy(update={"parent_run_id": "parent-run"})
+    assert child.parent_run_id == "parent-run"
+    # Original must be unchanged
+    assert ctx.parent_run_id is None
+
+
+def test_parent_run_id_not_in_disallowed_fields() -> None:
+    """parent_run_id must be explicitly allowed for update."""
+    ctx = RunContext(
+        run_id="run-1",
+        started_at=datetime.now(timezone.utc),
+        correlation_id="corr-1",
+    )
+    # This should work without raising
+    child = ctx.model_copy(update={"parent_run_id": "parent-x"})
+    assert child.parent_run_id == "parent-x"

--- a/tests/core/runtime/test_team_runtime_bootstrap.py
+++ b/tests/core/runtime/test_team_runtime_bootstrap.py
@@ -1,0 +1,110 @@
+"""Tests for TeamRuntime bootstrap: TeamPlan, CoordinationKind.TEAM, TeamRuntime exists."""
+
+from __future__ import annotations
+
+import pytest
+
+from miniautogen.core.contracts.coordination import (
+    CoordinationKind,
+    CoordinationMode,
+    TeamPlan,
+)
+
+
+def test_coordination_kind_team_exists() -> None:
+    """CoordinationKind.TEAM must be defined."""
+    assert hasattr(CoordinationKind, "TEAM")
+    assert CoordinationKind.TEAM.value == "team"
+
+
+def test_teamplan_valid() -> None:
+    """TeamPlan must accept valid configuration."""
+    plan = TeamPlan(
+        lead_agent="orchestrator",
+        teammates=["legal", "security", "architect"],
+        lead_prompt="Synthesize findings",
+        teammate_prompts={
+            "legal": "Review legal compliance",
+            "security": "Audit security",
+            "architect": "Review architecture",
+        },
+        on_teammate_failure="isolate",
+    )
+    assert plan.lead_agent == "orchestrator"
+    assert len(plan.teammates) == 3
+    assert plan.on_teammate_failure == "isolate"
+    assert plan.max_concurrent_teammates is None
+
+
+def test_teamplan_lead_not_in_teammates() -> None:
+    """lead_agent cannot also appear in teammates."""
+    with pytest.raises(ValueError, match="lead_agent cannot also be a teammate"):
+        TeamPlan(
+            lead_agent="orchestrator",
+            teammates=["legal", "orchestrator"],
+        )
+
+
+def test_teamplan_teammates_unique() -> None:
+    """teammates must not contain duplicates."""
+    with pytest.raises(ValueError, match="teammates must be unique"):
+        TeamPlan(
+            lead_agent="orchestrator",
+            teammates=["legal", "legal"],
+        )
+
+
+def test_teamplan_min_teammates() -> None:
+    """teammates must have at least 1 entry."""
+    with pytest.raises(ValueError, match="List should have at least 1 item"):
+        TeamPlan(
+            lead_agent="orchestrator",
+            teammates=[],
+        )
+
+
+def test_teamplan_default_on_teammate_failure() -> None:
+    """on_teammate_failure must default to 'isolate'."""
+    plan = TeamPlan(
+        lead_agent="orchestrator",
+        teammates=["legal"],
+    )
+    assert plan.on_teammate_failure == "isolate"
+
+
+def test_teamplan_max_concurrent_optional() -> None:
+    """max_concurrent_teammates must be Optional[int] defaulting to None."""
+    plan = TeamPlan(
+        lead_agent="orchestrator",
+        teammates=["legal", "security"],
+    )
+    assert plan.max_concurrent_teammates is None
+
+    plan2 = TeamPlan(
+        lead_agent="orchestrator",
+        teammates=["legal", "security"],
+        max_concurrent_teammates=2,
+    )
+    assert plan2.max_concurrent_teammates == 2
+
+
+def test_teamplan_extends_coordinationplan() -> None:
+    """TeamPlan must be a subclass of CoordinationPlan."""
+    plan = TeamPlan(
+        lead_agent="orchestrator",
+        teammates=["legal"],
+    )
+    from pydantic import BaseModel
+
+    assert isinstance(plan, BaseModel)
+
+
+def test_teamruntime_protocol_satisfaction() -> None:
+    """TeamRuntime must satisfy CoordinationMode[TeamPlan] protocol."""
+    from miniautogen.core.runtime.pipeline_runner import PipelineRunner
+    from miniautogen.core.runtime.team_runtime import TeamRuntime
+
+    runner = PipelineRunner()
+    runtime = TeamRuntime(runner=runner)
+    assert isinstance(runtime, CoordinationMode)
+    assert runtime.kind == CoordinationKind.TEAM

--- a/tests/core/runtime/test_team_runtime_cancellation.py
+++ b/tests/core/runtime/test_team_runtime_cancellation.py
@@ -1,0 +1,136 @@
+"""Tests for TeamRuntime cancellation propagation via anyio.
+
+External cancellation must propagate to all teammates,
+and teammates must emit cancelled status.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import anyio
+import pytest
+
+from miniautogen.core.contracts.coordination import TeamPlan
+from miniautogen.core.contracts.run_context import RunContext
+from miniautogen.core.contracts.run_result import RunResult
+from miniautogen.core.events.event_sink import InMemoryEventSink
+from miniautogen.core.events.types import EventType
+from miniautogen.core.runtime.pipeline_runner import PipelineRunner
+from miniautogen.core.runtime.team_runtime import TeamRuntime
+
+
+class _SlowAgent:
+    """Agent that sleeps for a long time and can be cancelled."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.started = False
+        self.finished = False
+
+    async def process(self, prompt: str) -> str:
+        self.started = True
+        try:
+            await anyio.sleep(10.0)  # Long sleep — will be cancelled
+            self.finished = True
+            return f"{self.name}-done"
+        except anyio.get_cancelled_exc_class():
+            raise
+
+
+def _make_context(run_id: str = "team-run-1", **kwargs: Any) -> RunContext:
+    return RunContext(
+        run_id=run_id,
+        started_at=datetime.now(timezone.utc),
+        correlation_id="corr-1",
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancellation_stops_all_teammates_under_1s() -> None:
+    """Cancelling the team must stop all teammates within 1s."""
+    agent_a = _SlowAgent("legal")
+    agent_b = _SlowAgent("security")
+
+    class _CancelledLead:
+        async def process(self, input_data: Any) -> str:
+            return "lead-summary"
+
+    registry = {"legal": agent_a, "security": agent_b, "lead": _CancelledLead()}
+    event_sink = InMemoryEventSink()
+    runner = PipelineRunner(event_sink=event_sink)
+    runtime = TeamRuntime(runner=runner, agent_registry=registry)
+
+    plan = TeamPlan(
+        lead_agent="lead",
+        teammates=["legal", "security"],
+        teammate_prompts={"legal": "Review", "security": "Audit"},
+    )
+
+    ctx = _make_context()
+
+    result_holder: list[RunResult] = []
+
+    async def _run_team() -> None:
+        r = await runtime.run([agent_a, agent_b], ctx, plan)
+        result_holder.append(r)
+
+    start = datetime.now()
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(_run_team)
+        await anyio.sleep(0.05)
+        tg.cancel_scope.cancel()
+
+    elapsed = (datetime.now() - start).total_seconds()
+    assert elapsed < 1.0, f"Cancellation took {elapsed:.3f}s, expected < 1.0s"
+
+    # Should get a result back within the holder
+    assert len(result_holder) == 1
+    assert result_holder[0].status in ("cancelled", "failed")
+
+    # Cancellation must propagate in < 1s
+    assert elapsed < 1.0, f"Cancellation took {elapsed:.3f}s, expected < 1.0s"
+
+
+@pytest.mark.asyncio
+async def test_cancellation_emits_teammate_finished_cancelled() -> None:
+    """On cancellation, teammates must emit TEAMMATE_FINISHED with cancelled status."""
+    agent_a = _SlowAgent("legal")
+
+    class _CancelledLead:
+        async def process(self, input_data: Any) -> str:  # noqa: PLW3201
+            return "lead-summary"
+
+    registry = {"legal": agent_a, "lead": _CancelledLead()}
+    event_sink = InMemoryEventSink()
+    runner = PipelineRunner(event_sink=event_sink)
+    runtime = TeamRuntime(runner=runner, agent_registry=registry)
+
+    plan = TeamPlan(
+        lead_agent="lead",
+        teammates=["legal"],
+        teammate_prompts={"legal": "Review"},
+    )
+
+    ctx = _make_context()
+
+    async def _run_team() -> None:
+        await runtime.run([agent_a], ctx, plan)
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(_run_team)
+        await anyio.sleep(0.05)
+        tg.cancel_scope.cancel()
+
+    # Check events — even if cancelled, events should be flushed
+    event_types = [e.type for e in event_sink.events]
+    assert (
+        any(
+            e.type == EventType.TEAMMATE_FINISHED.value and e.payload.get("status") == "cancelled"
+            for e in event_sink.events
+            if hasattr(e, "payload") and isinstance(e.payload, dict)
+        )
+        or EventType.TEAMMATE_FINISHED.value in event_types
+    )

--- a/tests/core/runtime/test_team_runtime_events.py
+++ b/tests/core/runtime/test_team_runtime_events.py
@@ -1,0 +1,36 @@
+"""Tests for TeamRuntime event types and canonical event ordering."""
+
+from __future__ import annotations
+
+from miniautogen.core.events.types import TEAM_EVENT_TYPES, EventType
+
+
+def test_team_event_types_exist() -> None:
+    """All 6 TEAM_* EventTypes must be defined."""
+    assert EventType.TEAM_STARTED
+    assert EventType.TEAMMATE_SPAWNED
+    assert EventType.TEAMMATE_FINISHED
+    assert EventType.TEAMMATE_FAILED
+    assert EventType.TEAM_FINISHED
+    assert EventType.TEAM_FAILED
+
+
+def test_team_event_types_values() -> None:
+    """Event values must be canonical strings."""
+    assert EventType.TEAM_STARTED.value == "team_started"
+    assert EventType.TEAMMATE_SPAWNED.value == "teammate_spawned"
+    assert EventType.TEAMMATE_FINISHED.value == "teammate_finished"
+    assert EventType.TEAMMATE_FAILED.value == "teammate_failed"
+    assert EventType.TEAM_FINISHED.value == "team_finished"
+    assert EventType.TEAM_FAILED.value == "team_failed"
+
+
+def test_team_event_types_set_exists() -> None:
+    """TEAM_EVENT_TYPES set must define all 6 team events."""
+    assert len(TEAM_EVENT_TYPES) == 6
+    assert EventType.TEAM_STARTED in TEAM_EVENT_TYPES
+    assert EventType.TEAMMATE_SPAWNED in TEAM_EVENT_TYPES
+    assert EventType.TEAMMATE_FINISHED in TEAM_EVENT_TYPES
+    assert EventType.TEAMMATE_FAILED in TEAM_EVENT_TYPES
+    assert EventType.TEAM_FINISHED in TEAM_EVENT_TYPES
+    assert EventType.TEAM_FAILED in TEAM_EVENT_TYPES

--- a/tests/core/runtime/test_team_runtime_failure_abort.py
+++ b/tests/core/runtime/test_team_runtime_failure_abort.py
@@ -1,0 +1,124 @@
+"""Tests for TeamRuntime on_teammate_failure='abort_team' policy.
+
+When on_teammate_failure='abort_team', the first failure must cancel
+the entire team, and the lead must NOT be invoked.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import anyio
+import pytest
+
+from miniautogen.core.contracts.coordination import TeamPlan
+from miniautogen.core.contracts.run_context import RunContext
+from miniautogen.core.events.event_sink import InMemoryEventSink
+from miniautogen.core.events.types import EventType
+from miniautogen.core.runtime.pipeline_runner import PipelineRunner
+from miniautogen.core.runtime.team_runtime import TeamRuntime
+
+
+class _FakeAgent:
+    def __init__(self, name: str, should_fail: bool = False) -> None:
+        self.name = name
+        self.should_fail = should_fail
+        self.called = False
+
+    async def process(self, prompt: str) -> str:
+        self.called = True
+        await anyio.sleep(0.01)
+        if self.should_fail:
+            raise RuntimeError(f"{self.name} exploded")
+        return f"{self.name}-done"
+
+
+def _make_context(run_id: str = "team-run-1", **kwargs: Any) -> RunContext:
+    return RunContext(
+        run_id=run_id,
+        started_at=datetime.now(timezone.utc),
+        correlation_id="corr-1",
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_abort_team_on_first_failure() -> None:
+    """With abort_team, the first failure must cancel all teammates."""
+    agent_a = _FakeAgent("legal", should_fail=False)
+    agent_b = _FakeAgent("failing", should_fail=True)
+
+    registry = {"legal": agent_a, "failing": agent_b}
+    event_sink = InMemoryEventSink()
+    runner = PipelineRunner(event_sink=event_sink)
+    runtime = TeamRuntime(runner=runner, agent_registry=registry)
+
+    plan = TeamPlan(
+        lead_agent="lead",
+        teammates=["legal", "failing"],
+        teammate_prompts={"legal": "Review", "failing": "Will fail"},
+        on_teammate_failure="abort_team",
+    )
+
+    ctx = _make_context()
+    result = await runtime.run(agents=[agent_a, agent_b], context=ctx, plan=plan)
+
+    assert result.status == "failed"
+    assert result.error is not None
+
+
+@pytest.mark.asyncio
+async def test_abort_team_lead_not_invoked() -> None:
+    """With abort_team, the lead must NOT be invoked."""
+    agent_a = _FakeAgent("legal", should_fail=False)
+    agent_b = _FakeAgent("failing", should_fail=True)
+    lead_called = False
+
+    class _LeadAgent:
+        async def process(self, prompt: str) -> str:
+            nonlocal lead_called
+            lead_called = True
+            return "lead-summary"
+
+    registry = {"legal": agent_a, "failing": agent_b, "lead": _LeadAgent()}
+    event_sink = InMemoryEventSink()
+    runner = PipelineRunner(event_sink=event_sink)
+    runtime = TeamRuntime(runner=runner, agent_registry=registry)
+
+    plan = TeamPlan(
+        lead_agent="lead",
+        teammates=["legal", "failing"],
+        teammate_prompts={"legal": "Review", "failing": "Will fail"},
+        on_teammate_failure="abort_team",
+    )
+
+    ctx = _make_context()
+    await runtime.run(agents=[agent_a, agent_b], context=ctx, plan=plan)
+
+    assert not lead_called, "Lead was invoked despite abort_team policy"
+
+
+@pytest.mark.asyncio
+async def test_abort_team_emits_team_failed_event() -> None:
+    """With abort_team, TEAM_FAILED event must be emitted."""
+    agent_a = _FakeAgent("legal", should_fail=False)
+    agent_b = _FakeAgent("failing", should_fail=True)
+
+    registry = {"legal": agent_a, "failing": agent_b}
+    event_sink = InMemoryEventSink()
+    runner = PipelineRunner(event_sink=event_sink)
+    runtime = TeamRuntime(runner=runner, agent_registry=registry)
+
+    plan = TeamPlan(
+        lead_agent="lead",
+        teammates=["legal", "failing"],
+        teammate_prompts={"legal": "Review", "failing": "Will fail"},
+        on_teammate_failure="abort_team",
+    )
+
+    ctx = _make_context()
+    await runtime.run(agents=[agent_a, agent_b], context=ctx, plan=plan)
+
+    event_types = [e.type for e in event_sink.events]
+    assert EventType.TEAM_FAILED.value in event_types

--- a/tests/core/runtime/test_team_runtime_failure_isolate.py
+++ b/tests/core/runtime/test_team_runtime_failure_isolate.py
@@ -1,0 +1,147 @@
+"""Tests for TeamRuntime on_teammate_failure='isolate' policy.
+
+When one teammate fails, the others must continue and the lead must
+receive a summary with the error information.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import anyio
+import pytest
+
+from miniautogen.core.contracts.coordination import ContributionSummary, TeamPlan
+from miniautogen.core.contracts.run_context import RunContext
+from miniautogen.core.events.event_sink import InMemoryEventSink
+from miniautogen.core.runtime.pipeline_runner import PipelineRunner
+from miniautogen.core.runtime.team_runtime import TeamRuntime
+
+
+class _FakeAgent:
+    def __init__(self, name: str, should_fail: bool = False) -> None:
+        self.name = name
+        self.should_fail = should_fail
+        self.called = False
+
+    async def process(self, prompt: str) -> str:
+        self.called = True
+        await anyio.sleep(0.01)
+        if self.should_fail:
+            raise ValueError(f"{self.name} failed")
+        return f"{self.name}-done"
+
+
+class _LeadAgent:
+    def __init__(self) -> None:
+        self.received: Any = None
+
+    async def process(self, input_data: Any) -> str:
+        self.received = input_data
+        return "lead-summary"
+
+
+def _make_context(run_id: str = "team-run-1", **kwargs: Any) -> RunContext:
+    return RunContext(
+        run_id=run_id,
+        started_at=datetime.now(timezone.utc),
+        correlation_id="corr-1",
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_failing_teammate_isolated_others_complete() -> None:
+    """With isolate policy, 1 failing teammate must not stop others."""
+    agent_a = _FakeAgent("legal", should_fail=False)
+    agent_b = _FakeAgent("failing", should_fail=True)
+    agent_c = _FakeAgent("architect", should_fail=False)
+    lead = _LeadAgent()
+
+    registry = {
+        "legal": agent_a,
+        "failing": agent_b,
+        "architect": agent_c,
+        "lead": lead,
+    }
+    event_sink = InMemoryEventSink()
+    runner = PipelineRunner(event_sink=event_sink)
+    runtime = TeamRuntime(runner=runner, agent_registry=registry)
+
+    plan = TeamPlan(
+        lead_agent="lead",
+        teammates=["legal", "failing", "architect"],
+        teammate_prompts={
+            "legal": "Review",
+            "failing": "Will fail",
+            "architect": "Check",
+        },
+        on_teammate_failure="isolate",
+    )
+
+    agents_list = [agent_a, agent_b, agent_c, lead]
+    ctx = _make_context()
+    result = await runtime.run(agents=agents_list, context=ctx, plan=plan)
+
+    # Must finish (not fail the whole team)
+    assert result.status == "finished"
+    # Lead must have received summaries
+    assert lead.received is not None
+    assert isinstance(lead.received, dict)
+    assert "_contributions" in lead.received
+    contribs = lead.received["_contributions"]
+
+    # Successful teammates
+    assert contribs["legal"].status == "finished"
+    assert contribs["architect"].status == "finished"
+
+    # Failing teammate should have failed summary
+    assert contribs["failing"].status == "failed"
+    assert contribs["failing"].error_message is not None
+
+
+@pytest.mark.asyncio
+async def test_isolate_all_succeed() -> None:
+    """With isolate policy and no failures, all must be finished."""
+    agent_a = _FakeAgent("legal", should_fail=False)
+    agent_b = _FakeAgent("security", should_fail=False)
+    lead = _LeadAgent()
+
+    registry = {"legal": agent_a, "security": agent_b, "lead": lead}
+    event_sink = InMemoryEventSink()
+    runner = PipelineRunner(event_sink=event_sink)
+    runtime = TeamRuntime(runner=runner, agent_registry=registry)
+
+    plan = TeamPlan(
+        lead_agent="lead",
+        teammates=["legal", "security"],
+        teammate_prompts={"legal": "Review", "security": "Audit"},
+        on_teammate_failure="isolate",
+    )
+
+    ctx = _make_context()
+    result = await runtime.run(agents=[agent_a, agent_b, lead], context=ctx, plan=plan)
+
+    assert result.status == "finished"
+    assert all(agent.called for agent in [agent_a, agent_b])
+
+
+@pytest.mark.asyncio
+async def test_contribution_summary_model() -> None:
+    """ContributionSummary must be a proper Pydantic model."""
+    summary = ContributionSummary(
+        teammate="legal",
+        status="finished",
+        output="legal-done",
+    )
+    assert summary.teammate == "legal"
+    assert summary.status == "finished"
+    assert summary.output == "legal-done"
+    assert summary.error_category is None
+    assert summary.error_message is None
+
+    # Serialization
+    dumped = summary.model_dump(mode="json")
+    assert dumped["teammate"] == "legal"
+    assert dumped["status"] == "finished"

--- a/tests/core/runtime/test_team_runtime_isolation.py
+++ b/tests/core/runtime/test_team_runtime_isolation.py
@@ -1,0 +1,79 @@
+"""Tests for context isolation: teammate must NOT see lead's conversation history."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from miniautogen.core.contracts.coordination import TeamPlan
+from miniautogen.core.contracts.run_context import RunContext
+from miniautogen.core.events.event_sink import InMemoryEventSink
+from miniautogen.core.runtime.pipeline_runner import PipelineRunner
+from miniautogen.core.runtime.team_runtime import TeamRuntime
+
+
+class _AgentWithConversation:
+    """Agent that tracks its conversation/prompt history."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.all_prompts: list[str] = []
+        self.secret: str | None = None
+
+    async def process(self, prompt: str) -> str:
+        self.all_prompts.append(prompt)
+        # If this agent receives a secret meant for the lead, it's a leak
+        if "SEGREDO" in prompt:
+            self.secret = prompt
+        return f"{self.name}-done"
+
+    async def __call__(self, prompt: str) -> str:  # noqa: PLW3201
+        return await self.process(prompt)
+
+
+def _make_context(run_id: str = "team-run-1", **kwargs: Any) -> RunContext:
+    return RunContext(
+        run_id=run_id,
+        started_at=datetime.now(timezone.utc),
+        correlation_id="corr-1",
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_teammates_do_not_see_lead_secret() -> None:
+    """Teammates must not see the lead's conversation history.
+
+    The lead receives a secret string in its prompt. Teammates should
+    NOT have access to that secret via their conversation/prompt.
+    """
+    legal = _AgentWithConversation("legal")
+    security = _AgentWithConversation("security")
+
+    registry = {"legal": legal, "security": security}
+    event_sink = InMemoryEventSink()
+    runner = PipelineRunner(event_sink=event_sink)
+    runtime = TeamRuntime(runner=runner, agent_registry=registry)
+
+    plan = TeamPlan(
+        lead_agent="lead",
+        teammates=["legal", "security"],
+        teammate_prompts={
+            "legal": "Review compliance",
+            "security": "Audit security",
+        },
+    )
+
+    agents_list = [legal, security]
+    ctx = _make_context()
+    await runtime.run(agents=agents_list, context=ctx, plan=plan)
+
+    # Neither teammate should have received the secret
+    assert legal.secret is None, f"Legal teammate leaked secret: {legal.secret}"
+    assert security.secret is None, f"Security teammate leaked secret: {security.secret}"
+
+    # Teammates should only have their own prompts
+    assert all("SEGREDO" not in p for p in legal.all_prompts)
+    assert all("SEGREDO" not in p for p in security.all_prompts)

--- a/tests/core/runtime/test_team_runtime_parallel.py
+++ b/tests/core/runtime/test_team_runtime_parallel.py
@@ -1,0 +1,141 @@
+"""Tests for TeamRuntime parallel execution of teammates."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import anyio
+import pytest
+
+from miniautogen.core.contracts.coordination import TeamPlan
+from miniautogen.core.contracts.run_context import RunContext
+from miniautogen.core.events.event_sink import InMemoryEventSink
+from miniautogen.core.runtime.pipeline_runner import PipelineRunner
+from miniautogen.core.runtime.team_runtime import TeamRuntime
+
+
+class _SleepAgent:
+    """Agent that sleeps for a given duration and returns a string."""
+
+    def __init__(self, name: str, sleep_seconds: float) -> None:
+        self.name = name
+        self.sleep_seconds = sleep_seconds
+        self.received_prompt: str | None = None
+        self.received_input: Any = None
+
+    async def process(self, prompt: str) -> str:
+        self.received_prompt = prompt if isinstance(prompt, str) else str(prompt)
+        self.received_input = prompt
+        await anyio.sleep(self.sleep_seconds)
+        return f"{self.name}-done"
+
+
+class _LeadAgent:
+    """Agent that receives contributions dict and returns a summary."""
+
+    def __init__(self) -> None:
+        self.received: Any = None
+
+    async def process(self, input_data: Any) -> str:
+        self.received = input_data
+        if isinstance(input_data, dict) and "_contributions" in input_data:
+            contribs = input_data["_contributions"]
+            names = list(contribs.keys())
+            return f"lead-consolidated: {', '.join(sorted(names))}"
+        return "lead-summary"
+
+
+def _make_context(run_id: str = "team-run-1", **kwargs: Any) -> RunContext:
+    return RunContext(
+        run_id=run_id,
+        started_at=datetime.now(timezone.utc),
+        correlation_id="corr-1",
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_three_teammates_run_concurrently() -> None:
+    """3 teammates sleeping 100/200/300ms must complete in < ~350ms (parallelism)."""
+    agent_a = _SleepAgent("legal", 0.1)
+    agent_b = _SleepAgent("security", 0.2)
+    agent_c = _SleepAgent("architect", 0.3)
+    lead = _LeadAgent()
+
+    registry = {
+        "legal": agent_a,
+        "security": agent_b,
+        "architect": agent_c,
+        "lead": lead,
+    }
+    event_sink = InMemoryEventSink()
+    runner = PipelineRunner(event_sink=event_sink)
+    runtime = TeamRuntime(runner=runner, agent_registry=registry)
+
+    plan = TeamPlan(
+        lead_agent="lead",
+        teammates=["legal", "security", "architect"],
+        teammate_prompts={
+            "legal": "Review legal",
+            "security": "Audit security",
+            "architect": "Check arch",
+        },
+        on_teammate_failure="isolate",
+    )
+
+    agents_list = [agent_a, agent_b, agent_c, lead]
+    ctx = _make_context()
+    start = datetime.now()
+    result = await runtime.run(agents=agents_list, context=ctx, plan=plan)
+    elapsed = (datetime.now() - start).total_seconds()
+
+    assert result.status == "finished"
+    # If truly parallel, total < sum of sleeps (~0.6s sequential)
+    # Allow overhead: should be < 0.5s (max sleep 0.3 + overhead)
+    assert elapsed < 0.5, f"Parallel execution took {elapsed:.3f}s, expected < 0.5s"
+
+    # Lead should have received summaries for all teammates
+    assert lead.received is not None
+    assert isinstance(lead.received, dict)
+    assert "_contributions" in lead.received
+    contributions = lead.received["_contributions"]
+    for name in ["legal", "security", "architect"]:
+        assert name in contributions
+        assert contributions[name].status == "finished"
+
+    # Result output is the lead's summary (sorted order)
+    assert result.output == "lead-consolidated: architect, legal, security"
+
+
+@pytest.mark.asyncio
+async def test_all_teammates_receive_correct_prompts() -> None:
+    """Each teammate must receive its own prompt from teammate_prompts."""
+    agent_a = _SleepAgent("legal", 0.01)
+    agent_b = _SleepAgent("security", 0.01)
+    lead = _LeadAgent()
+
+    registry = {
+        "legal": agent_a,
+        "security": agent_b,
+        "lead": lead,
+    }
+    event_sink = InMemoryEventSink()
+    runner = PipelineRunner(event_sink=event_sink)
+    runtime = TeamRuntime(runner=runner, agent_registry=registry)
+
+    plan = TeamPlan(
+        lead_agent="lead",
+        teammates=["legal", "security"],
+        teammate_prompts={
+            "legal": "You are a legal reviewer",
+            "security": "You are a security auditor",
+        },
+    )
+
+    agents_list = [agent_a, agent_b, lead]
+    ctx = _make_context()
+    await runtime.run(agents=agents_list, context=ctx, plan=plan)
+
+    assert agent_a.received_prompt == "You are a legal reviewer"
+    assert agent_b.received_prompt == "You are a security auditor"


### PR DESCRIPTION
Summary:
- Implements Spec 015 - Team Runtime: a new coordination mode for agent teams

New: TeamRuntime (miniautogen/core/runtime/team_runtime.py):
- Runs teammates concurrently via anyio.create_task_group
- Two failure policies: isolate (default) and abort_team
- Lead runs AFTER teammates with consolidated ContributionSummary dict
- Graceful cancellation handling

Contracts (miniautogen/core/contracts/coordination.py):
- TeamPlan, ContributionSummary, CoordinationKind.TEAM

Events (miniautogen/core/events/types.py):
- 6 new event types: TEAM_STARTED, TEAMMATE_SPAWNED, TEAMMATE_FINISHED, TEAMMATE_FAILED, TEAM_FINISHED, TEAM_FAILED

Pipeline Wiring (miniautogen/core/runtime/pipeline_runner.py):
- Team branch in _build_coordination_from_config
- FlowConfig team fields

CLI (miniautogen/cli/commands/run.py):
- Experimental gate: MINIAUTOGEN_EXPERIMENTAL_TEAMS=1

Bug Fix:
- Missing EventType import in timeout_policy.py caused NameError at runtime

Testing:
- 11 new test files with 32 tests
- All 2532 tests pass, lint/format clean