### PR TITLE
fix(runtime): enforce team runtime policies

### DIFF
--- a/miniautogen/core/runtime/team_runtime.py
+++ b/miniautogen/core/runtime/team_runtime.py
@@ -27,6 +27,10 @@ if TYPE_CHECKING:
     from miniautogen.core.runtime.pipeline_runner import PipelineRunner
 
 
+class TeamAgentTimeout(Exception):
+    """Raised internally when a team agent turn times out."""
+
+
 class TeamRuntime:
     """Coordination mode for agent teams with a lead and concurrent teammates.
 
@@ -95,6 +99,11 @@ class TeamRuntime:
         contributions: dict[str, ContributionSummary] = {}
         abort = False
         was_cancelled = False
+        limiter = (
+            anyio.CapacityLimiter(plan.max_concurrent_teammates)
+            if plan.max_concurrent_teammates is not None
+            else None
+        )
 
         try:
             async with anyio.create_task_group() as tg:
@@ -135,6 +144,7 @@ class TeamRuntime:
                         contributions,
                         run_id,
                         tg.cancel_scope,
+                        limiter,
                     )
 
                 if abort:
@@ -223,15 +233,27 @@ class TeamRuntime:
         contributions: dict[str, ContributionSummary],
         run_id: str,
         cancel_scope: anyio.CancelScope | None = None,
+        limiter: anyio.CapacityLimiter | None = None,
     ) -> None:
         """Run a single teammate, capturing result or failure."""
         try:
-            if hasattr(agent, "process"):
-                output = await agent.process(prompt)
-            elif callable(agent):
-                output = await agent(prompt)
+            if limiter is None:
+                output = await self._invoke_agent(
+                    agent_id=name,
+                    agent=agent,
+                    input_data=prompt,
+                    context=context,
+                    round_name="teammate",
+                )
             else:
-                output = await agent(prompt)
+                async with limiter:
+                    output = await self._invoke_agent(
+                        agent_id=name,
+                        agent=agent,
+                        input_data=prompt,
+                        context=context,
+                        round_name="teammate",
+                    )
 
             contributions[name] = ContributionSummary(
                 teammate=name,
@@ -262,6 +284,25 @@ class TeamRuntime:
                 },
             )
             raise
+        except TeamAgentTimeout:
+            contributions[name] = ContributionSummary(
+                teammate=name,
+                status="failed",
+                error_category="timeout",
+                error_message="agent_timeout",
+            )
+            await self._emit(
+                EventType.TEAMMATE_FAILED,
+                run_id,
+                payload={
+                    "teammate": name,
+                    "sub_run_id": f"{run_id}/{name}",
+                    "error_category": "timeout",
+                    "message": "agent_timeout",
+                },
+            )
+            if failure_policy == "abort_team" and cancel_scope is not None:
+                cancel_scope.cancel()
         except Exception as exc:
             error_category = "execution"
             contributions[name] = ContributionSummary(
@@ -303,23 +344,24 @@ class TeamRuntime:
         lead_prompt = plan.lead_prompt or "Consolidate the team findings."
 
         try:
-            if hasattr(lead_agent, "process"):
-                output = await lead_agent.process(
-                    {"_contributions": contributions, "_prompt": lead_prompt},
-                )
-            elif callable(lead_agent):
-                output = await lead_agent(
-                    {"_contributions": contributions, "_prompt": lead_prompt},
-                )
-            else:
-                output = await lead_agent(
-                    {"_contributions": contributions, "_prompt": lead_prompt},
-                )
+            output = await self._invoke_agent(
+                agent_id=plan.lead_agent,
+                agent=lead_agent,
+                input_data={"_contributions": contributions, "_prompt": lead_prompt},
+                context=context,
+                round_name="lead",
+            )
 
             return RunResult(
                 run_id=run_id,
                 status=RunStatus.FINISHED,
                 output=output,
+            )
+        except TeamAgentTimeout:
+            return RunResult(
+                run_id=run_id,
+                status=RunStatus.TIMED_OUT,
+                error="agent_timeout",
             )
         except Exception as exc:
             error = str(exc)
@@ -346,6 +388,66 @@ class TeamRuntime:
                 )
                 raise ValueError(msg)
 
+    async def _invoke_agent(
+        self,
+        *,
+        agent_id: str,
+        agent: Any,
+        input_data: Any,
+        context: RunContext,
+        round_name: str,
+    ) -> Any:
+        """Invoke an agent with child context and optional timeout policy."""
+        if self._timeout_policy is None:
+            return await self._call_agent_with_context(agent, input_data, context)
+
+        result = None
+        timed_out = False
+
+        async def emit_timeout_event(event_type: str, **payload: object) -> None:
+            nonlocal timed_out
+            if event_type == EventType.AGENT_TURN_TIMED_OUT.value:
+                timed_out = True
+            await self._emit_raw(
+                event_type,
+                context.run_id,
+                correlation_id=context.correlation_id,
+                payload=payload,
+            )
+
+        try:
+            async with self._timeout_policy.scope_for_turn(
+                agent_id=agent_id,
+                round_name=round_name,
+                emit=emit_timeout_event,
+            ):
+                result = await self._call_agent_with_context(agent, input_data, context)
+        except TimeoutError as exc:
+            raise TeamAgentTimeout("agent_timeout") from exc
+
+        if timed_out:
+            raise TeamAgentTimeout("agent_timeout")
+        return result
+
+    async def _call_agent_with_context(
+        self,
+        agent: Any,
+        input_data: Any,
+        context: RunContext,
+    ) -> Any:
+        """Call an agent while temporarily applying the provided RunContext."""
+        previous_context = getattr(agent, "_run_context", None)
+        has_context = hasattr(agent, "_run_context")
+        if has_context:
+            agent._run_context = context  # noqa: SLF001
+        try:
+            if hasattr(agent, "process"):
+                return await agent.process(input_data)
+            return await agent(input_data)
+        finally:
+            if has_context:
+                agent._run_context = previous_context  # noqa: SLF001
+
     async def _emit(
         self,
         event_type: EventType,
@@ -361,6 +463,27 @@ class TeamRuntime:
             timestamp=datetime.now(timezone.utc),
             run_id=run_id,
             correlation_id=run_id,
+            scope="team_runtime",
+            payload=payload or {},
+        )
+        await self._runner.event_sink.publish(event)
+
+    async def _emit_raw(
+        self,
+        event_type: str,
+        run_id: str,
+        *,
+        correlation_id: str,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        """Emit a raw event type through the runner's event sink."""
+        from miniautogen.core.contracts.events import ExecutionEvent
+
+        event = ExecutionEvent(
+            type=event_type,
+            timestamp=datetime.now(timezone.utc),
+            run_id=run_id,
+            correlation_id=correlation_id,
             scope="team_runtime",
             payload=payload or {},
         )

--- a/tests/core/runtime/test_team_runtime_isolation.py
+++ b/tests/core/runtime/test_team_runtime_isolation.py
@@ -33,6 +33,18 @@ class _AgentWithConversation:
         return await self.process(prompt)
 
 
+class _AgentWithRuntimeContext:
+    """AgentRuntime-like test double that exposes its current RunContext."""
+
+    def __init__(self, context: RunContext) -> None:
+        self._run_context = context
+        self.seen_parent_run_id: str | None = None
+
+    async def process(self, prompt: str) -> str:
+        self.seen_parent_run_id = self._run_context.parent_run_id
+        return "done"
+
+
 def _make_context(run_id: str = "team-run-1", **kwargs: Any) -> RunContext:
     return RunContext(
         run_id=run_id,
@@ -77,3 +89,28 @@ async def test_teammates_do_not_see_lead_secret() -> None:
     # Teammates should only have their own prompts
     assert all("SEGREDO" not in p for p in legal.all_prompts)
     assert all("SEGREDO" not in p for p in security.all_prompts)
+
+
+@pytest.mark.asyncio
+async def test_teammate_runtime_context_has_parent_run_id() -> None:
+    """AgentRuntime-backed teammates must execute with parent_run_id set."""
+    team_ctx = _make_context(run_id="team-run-parent")
+    initial_agent_ctx = _make_context(run_id="team-run-parent")
+    legal = _AgentWithRuntimeContext(initial_agent_ctx)
+
+    class _Lead:
+        async def process(self, prompt: Any) -> str:
+            return "lead-summary"
+
+    registry = {"legal": legal, "lead": _Lead()}
+    event_sink = InMemoryEventSink()
+    runner = PipelineRunner(event_sink=event_sink)
+    runtime = TeamRuntime(runner=runner, agent_registry=registry)
+
+    plan = TeamPlan(lead_agent="lead", teammates=["legal"])
+
+    result = await runtime.run(agents=[], context=team_ctx, plan=plan)
+
+    assert result.status == "finished"
+    assert legal.seen_parent_run_id == "team-run-parent"
+    assert legal._run_context.parent_run_id is None

--- a/tests/core/runtime/test_team_runtime_parallel.py
+++ b/tests/core/runtime/test_team_runtime_parallel.py
@@ -46,6 +46,22 @@ class _LeadAgent:
         return "lead-summary"
 
 
+class _TrackedConcurrentAgent:
+    """Agent that records active concurrency while it runs."""
+
+    active = 0
+    max_seen = 0
+
+    async def process(self, prompt: str) -> str:
+        type(self).active += 1
+        type(self).max_seen = max(type(self).max_seen, type(self).active)
+        try:
+            await anyio.sleep(0.05)
+            return "done"
+        finally:
+            type(self).active -= 1
+
+
 def _make_context(run_id: str = "team-run-1", **kwargs: Any) -> RunContext:
     return RunContext(
         run_id=run_id,
@@ -139,3 +155,27 @@ async def test_all_teammates_receive_correct_prompts() -> None:
 
     assert agent_a.received_prompt == "You are a legal reviewer"
     assert agent_b.received_prompt == "You are a security auditor"
+
+
+@pytest.mark.asyncio
+async def test_max_concurrent_teammates_limits_parallelism() -> None:
+    """max_concurrent_teammates must cap active teammate tasks."""
+    _TrackedConcurrentAgent.active = 0
+    _TrackedConcurrentAgent.max_seen = 0
+
+    registry = {f"agent_{i}": _TrackedConcurrentAgent() for i in range(5)}
+    registry["lead"] = _LeadAgent()
+    event_sink = InMemoryEventSink()
+    runner = PipelineRunner(event_sink=event_sink)
+    runtime = TeamRuntime(runner=runner, agent_registry=registry)
+
+    plan = TeamPlan(
+        lead_agent="lead",
+        teammates=list(registry.keys())[:-1],
+        max_concurrent_teammates=2,
+    )
+
+    result = await runtime.run(agents=[], context=_make_context(), plan=plan)
+
+    assert result.status == "finished"
+    assert _TrackedConcurrentAgent.max_seen <= 2

--- a/tests/core/runtime/test_team_runtime_timeout.py
+++ b/tests/core/runtime/test_team_runtime_timeout.py
@@ -1,0 +1,74 @@
+"""Tests for TeamRuntime timeout policy integration."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import anyio
+import pytest
+
+from miniautogen.core.contracts.coordination import TeamPlan
+from miniautogen.core.contracts.run_context import RunContext
+from miniautogen.core.events.event_sink import InMemoryEventSink
+from miniautogen.core.events.types import EventType
+from miniautogen.core.runtime.pipeline_runner import PipelineRunner
+from miniautogen.core.runtime.team_runtime import TeamRuntime
+from miniautogen.policies.timeout_policy import TimeoutPolicy
+
+
+class _SlowAgent:
+    async def process(self, prompt: str) -> str:
+        await anyio.sleep(0.2)
+        return "slow-done"
+
+
+class _LeadAgent:
+    def __init__(self) -> None:
+        self.received: Any = None
+
+    async def process(self, input_data: Any) -> str:
+        self.received = input_data
+        return "lead-summary"
+
+
+def _make_context(run_id: str = "team-run-timeout") -> RunContext:
+    return RunContext(
+        run_id=run_id,
+        started_at=datetime.now(timezone.utc),
+        correlation_id=run_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_teammate_timeout_uses_timeout_policy() -> None:
+    """A timed-out teammate must stop quickly and be reported to the lead."""
+    lead = _LeadAgent()
+    event_sink = InMemoryEventSink()
+    runner = PipelineRunner(event_sink=event_sink)
+    timeout_policy = TimeoutPolicy(
+        agent_timeouts={"slow": 0.01},
+        round_timeouts={},
+        flow_timeout=None,
+        engine_timeout=120.0,
+        on_timeout_action="continue",
+    )
+    runtime = TeamRuntime(
+        runner=runner,
+        agent_registry={"slow": _SlowAgent(), "lead": lead},
+        timeout_policy=timeout_policy,
+    )
+    plan = TeamPlan(lead_agent="lead", teammates=["slow"])
+
+    start = anyio.current_time()
+    result = await runtime.run(agents=[], context=_make_context(), plan=plan)
+    elapsed = anyio.current_time() - start
+
+    assert result.status == "finished"
+    assert elapsed < 0.1
+    assert lead.received is not None
+    contribution = lead.received["_contributions"]["slow"]
+    assert contribution.status == "failed"
+    assert contribution.error_category == "timeout"
+    assert contribution.error_message == "agent_timeout"
+    assert any(e.type == EventType.AGENT_TURN_TIMED_OUT.value for e in event_sink.events)


### PR DESCRIPTION
## Summary
- Enforce `max_concurrent_teammates` with an AnyIO capacity limiter.
- Route teammate and lead calls through TeamRuntime's timeout policy integration.
- Execute AgentRuntime-backed teammates with a temporary child `RunContext` containing `parent_run_id`, restoring the original context after the turn.
- Add regression coverage for timeout handling, concurrency caps, and context propagation.

## Root Cause
The original TeamRuntime accepted timeout and concurrency configuration, and built child run contexts, but its agent calls bypassed all three at the actual invocation boundary.

## Validation
- `uv run ruff check miniautogen/core/runtime/team_runtime.py tests/core/runtime/test_team_runtime_parallel.py tests/core/runtime/test_team_runtime_isolation.py tests/core/runtime/test_team_runtime_timeout.py`
- `uv run pytest tests/core/runtime/test_team_runtime_*.py tests/core/contracts/test_run_context_parent.py tests/core/contracts/test_coordination.py tests/cli/test_team_command.py tests/architecture/test_team_runtime_isolation.py -q`
- `uv run pytest tests --ignore=tests/tui -q`

## Notes
- Branch was recreated from `origin/develop` and the fix commit was cherry-picked cleanly, so there were no remaining merge conflicts.
